### PR TITLE
Alter schema to use children to allow for correct ordering

### DIFF
--- a/manifest_schema_v1_0.json
+++ b/manifest_schema_v1_0.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "manifest_schema_v1_0",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "module": {
+      "type": "object",
+      "additionalProperties": false,
+      "title": "A course content module",
+      "properties": {
+        "title": {
+          "type": "string",
+          "title": "The title of the content module"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "module"
+          ]
+        },
+        "descriptionFileName": {
+          "type": "string",
+          "title": "The file name of the content module description content"
+        },
+        "dueDate": {
+          "type": "string",
+          "title": "The content topic due date"
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/topic"
+              },
+              {
+                "$ref": "#/definitions/module"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "title",
+        "type",
+        "children"
+      ]
+    },
+    "topic": {
+      "type": "object",
+      "additionalProperties": false,
+      "title": "A course content topic",
+      "properties": {
+        "title": {
+          "type": "string",
+          "title": "The title of the content topic"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "topic"
+          ]
+        },
+        "dueDate": {
+          "type": "string",
+          "title": "The content topic due date"
+        },
+        "fileName": {
+          "type": "string",
+          "title": "The file name of the content topic"
+        },
+        "isRequired": {
+          "type": "boolean",
+          "title": "Indicates if the content topic is required for completion"
+        }
+      },
+      "required": [
+        "title",
+        "type",
+        "fileName"
+      ]
+    }
+  },
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "title": "The schema which uniquely identifies the manifest type"
+    },
+    "modules": {
+      "type": "array",
+      "title": "The course modules",
+      "items": {
+        "$ref": "#/definitions/module"
+      }
+    }
+  },
+  "required": [
+    "$schema",
+    "modules"
+  ]
+}

--- a/src/test/content/manifest.json
+++ b/src/test/content/manifest.json
@@ -1,12 +1,15 @@
 {
+  "$schema": "../../../manifest_schema_v1_0.json",
   "modules": [
     {
       "title": "Test Module",
+      "type": "module",
       "descriptionFileName": "test-module/index.md",
       "dueDate": "2020-01-01T00:00:00.000Z",
-      "topics": [
+      "children": [
         {
           "title": "Test Topic",
+          "type": "topic",
           "fileName": "test-module/test-topic.md",
           "isRequired": false
         }


### PR DESCRIPTION
Alters the schema to use children instead of topics and submodules to
allow for module children to be created in the correct order.

Fixes: #5