### PR TITLE
Add support for quizzes

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -496,6 +496,108 @@ module.exports.default = exports.default;
 
 /***/ }),
 
+/***/ 131:
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+"use strict";
+
+
+const { DryRunFakeModule, LEVersion } = __webpack_require__(648);
+const ContentFactory = __webpack_require__(788);
+
+module.exports = class QuizProcessor {
+	constructor(
+		{ isDryRun = false },
+		valence,
+		fetch = __webpack_require__(454)
+	) {
+		this._dryRun = isDryRun;
+
+		this._fetch = fetch;
+		this._valence = valence;
+	}
+
+	async processQuiz(instanceUrl, orgUnit, quiz, parentModule) {
+		const quizzes = await this._getQuizzes(instanceUrl, orgUnit);
+		const quizItem = quizzes.Objects && Array.isArray(quizzes.Objects) && quizzes.Objects.find(x => x.Name === quiz.title);
+
+		const content = await this._getContent(instanceUrl, orgUnit, parentModule);
+		const self = Array.isArray(content) && content.find(x => x.Type === 1 && x.TopicType === 3 && x.Title === quiz.title);
+
+		if (self) {
+			// Nothing to do, the quicklink exists
+			return self;
+		}
+
+		return this._createQuizTopic({ instanceUrl, orgUnit, quiz, parentModule, quizItem });
+	}
+
+	async _createQuizTopic({ instanceUrl, orgUnit, quiz, parentModule, quizItem }) {
+		console.log(`Creating quiz topic: '${quiz.title}'`);
+
+		const url = new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Id}/content/modules/${parentModule.Id}/structure/`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'POST');
+
+		const rcode = quizItem.ActivityId.split('/').slice(-1)[0];
+		const topic = ContentFactory.createTopic({
+			title: quiz.title,
+			topicType: 3,
+			url: `/d2l/common/dialogs/quickLink/quickLink.d2l?ou=${orgUnit.Id}&type=quiz&rcode=${rcode}`
+		});
+
+		if (this._dryRun) {
+			return;
+		}
+
+		const response = await this._fetch(
+			signedUrl,
+			{
+				method: 'POST',
+				body: JSON.stringify(topic)
+			}
+		);
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return response.json();
+	}
+
+	async _getContent(instanceUrl, orgUnit, parentModule) {
+		const url = new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Id}/content/modules/${parentModule.Id}/structure/`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'GET');
+
+		if (this._dryRun && parentModule.Id === DryRunFakeModule.Id) {
+			return DryRunFakeModule;
+		}
+
+		const response = await this._fetch(signedUrl);
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return response.json();
+	}
+
+	async _getQuizzes(instanceUrl, orgUnit) {
+		const url = new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Id}/quizzes/`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'GET');
+
+		const response = await this._fetch(signedUrl);
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return response.json();
+	}
+};
+
+
+/***/ }),
+
 /***/ 141:
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -5244,7 +5346,8 @@ function clean(key)
 
 
 const fs = __webpack_require__(747);
-const FormData = __webpack_require__(928);
+
+const { LPVersion } = __webpack_require__(648);
 
 module.exports = class UploadCourseContent {
 	constructor(
@@ -5254,7 +5357,10 @@ module.exports = class UploadCourseContent {
 			isDryRun
 		},
 		valence,
-		fetch = __webpack_require__(454)
+		{
+			fetch = __webpack_require__(454),
+			ModuleProcessor = __webpack_require__(903)
+		}
 	) {
 		this._fetch = fetch;
 		this._valence = valence;
@@ -5263,6 +5369,8 @@ module.exports = class UploadCourseContent {
 		this._dryRun = isDryRun;
 
 		this._markdownRegex = /.md$/i;
+
+		this._moduleProcessor = new ModuleProcessor({ contentPath: contentDirectory, isDryRun }, valence);
 	}
 
 	/**
@@ -5275,263 +5383,18 @@ module.exports = class UploadCourseContent {
 		orgUnitId
 	) {
 		const whoAmI = await this._whoAmI(instanceUrl);
-		console.log(`Running in user context: ${whoAmI.UniqueName}`);
+		console.log(`Running in user context: '${whoAmI.UniqueName}'`);
 
 		const orgUnit = await this._getOrgUnit(instanceUrl, orgUnitId);
-		console.log(`Found course offering: ${orgUnit.Name} with id ${orgUnit.Identifier}`);
+		console.log(`Found course offering: '${orgUnit.Name}' with id: '${orgUnit.Identifier}'`);
 
 		const manifest = await this._getManifest();
-		console.log('Loaded manifest');
 
 		// Order matters on creates, so not using .map()
 		for (const module of manifest.modules) {
 			// eslint-disable-next-line no-await-in-loop
-			await this._processModule(instanceUrl, orgUnit, module);
+			await this._moduleProcessor.processModule(instanceUrl, orgUnit, module);
 		}
-	}
-
-	async _processModule(instanceUrl, orgUnit, module, parentModule) {
-		console.log(`Processing module: ${module.title}`);
-
-		const items = await this._getContent(instanceUrl, orgUnit, parentModule);
-		let self = Array.isArray(items) && items.find(m => m.Type === 0 && m.Title === module.title);
-
-		if (self) {
-			await this._updateModule(instanceUrl, orgUnit, module, self);
-		} else {
-			self = await this._createModule(instanceUrl, orgUnit, module, parentModule);
-		}
-
-		// Order matters on creates, so not using .map()
-		for (const child of module.children) {
-			if (child.type === 'topic') {
-				// eslint-disable-next-line no-await-in-loop
-				await this._processTopic(instanceUrl, orgUnit, child, self);
-			} else if (child.type === 'resource') {
-				// eslint-disable-next-line no-await-in-loop
-				await this._processResource(instanceUrl, orgUnit, child, self);
-			} else {
-				// eslint-disable-next-line no-await-in-loop
-				await this._processModule(instanceUrl, orgUnit, child, self);
-			}
-		}
-	}
-
-	async _processResource(instanceUrl, orgUnit, resource, parentModule) {
-		console.log(`Processing resource: ${resource.fileName}`);
-
-		const topic = {
-			...resource,
-			...{
-				title: resource.fileName
-			}
-		};
-
-		return this._processTopic(instanceUrl, orgUnit, topic, parentModule, true);
-	}
-
-	async _processTopic(instanceUrl, orgUnit, topic, parentModule, isHidden = false) {
-		console.log(`Processing topic: ${topic.title}`);
-
-		const topics = await this._getContent(instanceUrl, orgUnit, parentModule);
-		const self = Array.isArray(topics) && topics.find(t => t.Type === 1 && t.TopicType === 1 && t.Title === topic.title);
-
-		if (self) {
-			await this._updateTopic(instanceUrl, orgUnit, topic, self, isHidden);
-			return self;
-		}
-
-		return this._createTopic(instanceUrl, orgUnit, topic, parentModule, isHidden);
-	}
-
-	async _createModule(instanceUrl, orgUnit, module, parentModule) {
-		console.log(`Creating module: ${module.title}`);
-
-		const url = parentModule
-			? new URL(`/d2l/api/le/1.34/${orgUnit.Identifier}/content/modules/${parentModule.Id}/structure/`, instanceUrl)
-			: new URL(`/d2l/api/le/1.34/${orgUnit.Identifier}/content/root/`, instanceUrl);
-		const signedUrl = this._valence.createAuthenticatedUrl(url, 'POST');
-
-		const descriptionFileName = module.descriptionFileName.replace(this._markdownRegex, '.html');
-		const description = await fs.promises.readFile(`${this._contentDir}/${descriptionFileName}`);
-
-		if (this._dryRun) {
-			return UploadCourseContent.DRY_RUN_FAKE_MODULE;
-		}
-
-		const response = await this._fetch(
-			signedUrl,
-			{
-				method: 'POST',
-				body: JSON.stringify({
-					Title: module.title,
-					ShortTitle: module.title,
-					Type: 0,
-					ModuleStartDate: null,
-					ModuleEndDate: null,
-					ModuleDueDate: module.dueDate || null,
-					IsHidden: false,
-					IsLocked: false,
-					Description: {
-						Html: description.toString('utf-8')
-					}
-				})
-			});
-
-		return response.json();
-	}
-
-	async _createTopic(instanceUrl, orgUnit, topic, parentModule, isHidden = false) {
-		const fileName = topic.fileName.replace(this._markdownRegex, '.html');
-
-		console.log(`Creating topic: ${topic.title} with file: ${orgUnit.Path}${fileName}`);
-
-		const url = new URL(`/d2l/api/le/1.34/${orgUnit.Identifier}/content/modules/${parentModule.Id}/structure/`, instanceUrl);
-		const signedUrl = this._valence.createAuthenticatedUrl(url, 'POST');
-
-		const fileContent = await fs.promises.readFile(`${this._contentDir}/${fileName}`);
-
-		const formData = new FormData();
-		formData.append(
-			'',
-			JSON.stringify({
-				Title: topic.title,
-				ShortTitle: topic.title,
-				Type: 1,
-				TopicType: 1,
-				StartDate: null,
-				EndDate: null,
-				DueDate: topic.dueDate || null,
-				Url: `${orgUnit.Path}${fileName}`,
-				IsHidden: isHidden,
-				IsLocked: false,
-				IsExempt: !topic.isRequired
-			}),
-			{ contentType: 'application/json' }
-		);
-		formData.append(
-			'',
-			fileContent,
-			{ contentType: 'text/html', filename: `${fileName}` }
-		);
-
-		if (this._dryRun) {
-			return {};
-		}
-
-		const response = await this._fetch(
-			signedUrl,
-			{
-				method: 'POST',
-				headers: {
-					'Content-Type': `multipart/mixed; boundary=${formData.getBoundary()}`
-				},
-				body: formData
-			});
-
-		return response.json();
-	}
-
-	async _updateModule(instanceUrl, orgUnit, module, lmsModule, isHidden = false) {
-		console.log(`Updating module ${module.title}`);
-
-		const url = new URL(`/d2l/api/le/1.34/${orgUnit.Identifier}/content/modules/${lmsModule.Id}`, instanceUrl);
-		const signedUrl = this._valence.createAuthenticatedUrl(url, 'PUT');
-
-		const descriptionFileName = module.descriptionFileName.replace(this._markdownRegex, '.html');
-		const description = await fs.promises.readFile(`${this._contentDir}/${descriptionFileName}`);
-
-		const body = {
-			...lmsModule,
-			...{
-				Title: module.title,
-				ShortTitle: module.title,
-				ModuleDueDate: module.dueDate || null,
-				IsHidden: isHidden,
-				Description: {
-					Html: description.toString('utf-8')
-				}
-			}
-		};
-
-		if (this._dryRun) {
-			return body;
-		}
-
-		await this._fetch(
-			signedUrl,
-			{
-				method: 'PUT',
-				body: JSON.stringify(body)
-			});
-
-		return body;
-	}
-
-	async _updateTopic(instanceUrl, orgUnit, topic, lmsTopic) {
-		const url = new URL(`/d2l/api/le/1.34/${orgUnit.Identifier}/content/topics/${lmsTopic.Id}`, instanceUrl);
-		const signedUrl = this._valence.createAuthenticatedUrl(url, 'PUT');
-
-		const fileName = topic.fileName.replace(this._markdownRegex, '.html');
-
-		console.log(`Updating ${topic.title} and file ${fileName}`);
-
-		const body = {
-			...lmsTopic,
-			...{
-				Title: topic.title,
-				ShortTitle: topic.title,
-				Url: `${orgUnit.Path}${fileName}`,
-				DueDate: topic.dueDate || null,
-				ResetCompletionTracking: true,
-				IsExempt: !topic.isRequired
-			}
-		};
-
-		const fileUrl = new URL(`/d2l/api/le/1.34/${orgUnit.Identifier}/content/topics/${lmsTopic.Id}/file`, instanceUrl);
-		const signedFileUrl = this._valence.createAuthenticatedUrl(fileUrl, 'PUT');
-		const fileContent = await fs.promises.readFile(`${this._contentDir}/${fileName}`);
-
-		const formData = new FormData();
-		formData.append(
-			'file',
-			fileContent,
-			{ contentType: 'text/html', filename: `${fileName}` }
-		);
-
-		if (this._dryRun) {
-			return body;
-		}
-
-		await this._fetch(
-			signedUrl,
-			{
-				method: 'PUT',
-				body: JSON.stringify(body)
-			});
-
-		await this._fetch(
-			signedFileUrl,
-			{
-				method: 'PUT',
-				headers: {
-					'Content-Type': `multipart/mixed; boundary=${formData.getBoundary()}`
-				},
-				body: formData
-			});
-
-		return body;
-	}
-
-	async _getContent(instanceUrl, orgUnit, parentModule = null) {
-		const url = parentModule
-			? new URL(`/d2l/api/le/1.34/${orgUnit.Identifier}/content/modules/${parentModule.Id}/structure/`, instanceUrl)
-			: new URL(`/d2l/api/le/1.34/${orgUnit.Identifier}/content/root/`, instanceUrl);
-		const signedUrl = this._valence.createAuthenticatedUrl(url, 'GET');
-
-		const response = await this._fetch(signedUrl);
-
-		return response.json();
 	}
 
 	async _getManifest() {
@@ -5541,7 +5404,7 @@ module.exports = class UploadCourseContent {
 	}
 
 	async _getOrgUnit(instanceUrl, orgUnitId) {
-		const url = new URL(`/d2l/api/lp/1.23/courses/${orgUnitId}`, instanceUrl);
+		const url = new URL(`/d2l/api/lp/${LPVersion}/courses/${orgUnitId}`, instanceUrl);
 		const signedUrl = this._valence.createAuthenticatedUrl(url, 'GET');
 
 		const response = await this._fetch(signedUrl);
@@ -5550,16 +5413,12 @@ module.exports = class UploadCourseContent {
 	}
 
 	async _whoAmI(instanceUrl) {
-		const url = new URL('/d2l/api/lp/1.23/users/whoami', instanceUrl);
+		const url = new URL(`/d2l/api/lp/${LPVersion}/users/whoami`, instanceUrl);
 		const signedUrl = this._valence.createAuthenticatedUrl(url, 'GET');
 
 		const response = await this._fetch(signedUrl);
 
 		return response.json();
-	}
-
-	static get DRY_RUN_FAKE_MODULE() {
-		return { Id: 23487 };
 	}
 };
 
@@ -6169,6 +6028,23 @@ function isAscii(str) {
 
 module.exports = exports.default;
 module.exports.default = exports.default;
+
+/***/ }),
+
+/***/ 648:
+/***/ (function(module) {
+
+"use strict";
+
+
+module.exports = {
+	DryRunFakeModule: {
+		Id: 0
+	},
+	LEVersion: '1.46',
+	LPVersion: '1.28'
+};
+
 
 /***/ }),
 
@@ -7248,6 +7124,54 @@ module.exports.default = exports.default;
 
 /***/ }),
 
+/***/ 788:
+/***/ (function(module) {
+
+"use strict";
+
+
+module.exports = class ContentFactory {
+	static createRichText(content, type) {
+		return {
+			Content: content,
+			Type: type
+		};
+	}
+
+	static createModule({ title, description, dueDate = null }) {
+		return {
+			Title: title,
+			ShortTitle: title,
+			Type: 0,
+			ModuleStartDate: null,
+			ModuleEndDate: null,
+			ModuleDueDate: dueDate,
+			IsHidden: false,
+			IsLocked: false,
+			Description: description
+		};
+	}
+
+	static createTopic({ title, topicType = 1, dueDate = null, url, isHidden = false, isExempt = false }) {
+		return {
+			Title: title,
+			ShortTitle: title,
+			Type: 1,
+			TopicType: topicType,
+			StartDate: null,
+			EndDate: null,
+			DueDate: dueDate,
+			Url: url,
+			IsHidden: isHidden,
+			IsLocked: false,
+			IsExempt: isExempt
+		};
+	}
+};
+
+
+/***/ }),
+
 /***/ 790:
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -7755,6 +7679,351 @@ function descending(a, b)
 {
   return -1 * ascending(a, b);
 }
+
+
+/***/ }),
+
+/***/ 902:
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+"use strict";
+
+
+const fs = __webpack_require__(747);
+const FormData = __webpack_require__(928);
+
+const { DryRunFakeModule, LEVersion } = __webpack_require__(648);
+const ContentFactory = __webpack_require__(788);
+
+module.exports = class TopicProcessor {
+	constructor(
+		{ contentPath, isDryRun = false },
+		valence,
+		fetch = __webpack_require__(454)
+	) {
+		this._contentPath = contentPath;
+		this._dryRun = isDryRun;
+
+		this._fetch = fetch;
+		this._valence = valence;
+
+		this._markdownRegex = /.md$/i;
+	}
+
+	async processTopic({ instanceUrl, orgUnit, topic, parentModule, isHidden = false }) {
+		const topics = await this._getContent(instanceUrl, orgUnit, parentModule);
+		const self = Array.isArray(topics) && topics.find(x => x.Type === 1 && x.TopicType === 1 && x.Title === topic.title);
+
+		if (self) {
+			await this._updateTopic(instanceUrl, orgUnit, topic, self);
+			return self;
+		}
+
+		return this._createTopic({ instanceUrl, orgUnit, topic, parentModule, isHidden });
+	}
+
+	async _createTopic({ instanceUrl, orgUnit, topic, parentModule, isHidden }) {
+		const fileName = topic.fileName.replace(this._markdownRegex, '.html');
+
+		console.log(`Creating topic: '${topic.title}' with file: '${fileName}'`);
+
+		const url = new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Id}/content/modules/${parentModule.Id}/structure/`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'POST');
+
+		const fileContent = await fs.promises.readFile(`${this._contentPath}/${fileName}`);
+
+		const createTopic = ContentFactory.createTopic({
+			title: topic.title,
+			url: `${orgUnit.Path}${fileName}`,
+			dueDate: topic.dueDate,
+			isHidden,
+			isExempt: !topic.isRequired
+		});
+
+		const formData = new FormData();
+		formData.append(
+			'',
+			JSON.stringify(createTopic),
+			{ contentType: 'application/json' }
+		);
+		formData.append(
+			'',
+			fileContent,
+			{ contentType: 'text/html', filename: `${fileName}` }
+		);
+
+		const response = await this._fetch(
+			signedUrl,
+			{
+				method: 'POST',
+				headers: `multipart/mixed; ${formData.getBoundary()}`,
+				body: formData
+			});
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return response.json();
+	}
+
+	async _updateTopic(instanceUrl, orgUnit, topic, lmsTopic) {
+		const fileName = topic.fileName.replace(this._markdownRegex, '.html');
+
+		console.log(`Updating topic: '${topic.title}' with file: '${fileName}'`);
+
+		const url = new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Id}/content/topics/${lmsTopic.Id}`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'PUT');
+
+		const body = {
+			...lmsTopic,
+			...{
+				Title: topic.title,
+				ShortTitle: topic.title,
+				Url: `${orgUnit.Path}${fileName}`,
+				DueDate: topic.dueDate || null,
+				ResetCompletionTracking: true,
+				IsExempt: !topic.isRequired
+			}
+		};
+
+		if (!this._dryRun) {
+			const response = await this._fetch(
+				signedUrl,
+				{
+					method: 'PUT',
+					body: JSON.stringify(body)
+				});
+
+			if (!response.ok) {
+				throw new Error(response.statusText);
+			}
+		}
+
+		const fileUrl = new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Id}/content/topics/${lmsTopic.Id}/file`, instanceUrl);
+		const signedFileUrl = this._valence.createAuthenticatedUrl(fileUrl, 'PUT');
+
+		const fileContent = await fs.promises.readFile(`${this._contentPath}/${fileName}`);
+
+		const formData = new FormData();
+		formData.append(
+			'file',
+			fileContent,
+			{ contentType: 'text/html', filename: `${fileName}` }
+		);
+
+		if (!this._dryRun) {
+			const fileResponse = await this._fetch(
+				signedFileUrl,
+				{
+					method: 'PUT',
+					headers: {
+						'Content-Type': 'multipart/mixed'
+					},
+					body: formData
+				});
+
+			if (!fileResponse.ok) {
+				throw new Error(fileResponse.statusText);
+			}
+		}
+
+		return body;
+	}
+
+	async _getContent(instanceUrl, orgUnit, parentModule) {
+		const url = new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Id}/content/modules/${parentModule.Id}/structure/`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'GET');
+
+		if (this._dryRun && parentModule.Id === DryRunFakeModule.Id) {
+			return DryRunFakeModule;
+		}
+
+		const response = await this._fetch(signedUrl);
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return response.json();
+	}
+};
+
+
+/***/ }),
+
+/***/ 903:
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+"use strict";
+
+
+const fs = __webpack_require__(747);
+
+const ContentFactory = __webpack_require__(788);
+const { DryRunFakeModule, LEVersion } = __webpack_require__(648);
+
+module.exports = class ModuleProcessor {
+	constructor(
+		{ contentPath, isDryRun = false },
+		valence,
+		{
+			fetch = __webpack_require__(454),
+			TopicProcessor = __webpack_require__(902),
+			QuizProcessor = __webpack_require__(131)
+		}
+	) {
+		this._contentPath = contentPath;
+		this._dryRun = isDryRun;
+
+		this._fetch = fetch;
+		this._valence = valence;
+		this._topicProcessor = new TopicProcessor({ contentPath, isDryRun }, valence);
+		this._quizProcessor = new QuizProcessor({ isDryRun }, valence);
+
+		this._markdownRegex = /.md$/i;
+	}
+
+	async processModule(instanceUrl, orgUnit, module, parentModule = null) {
+		const items = await this._getContent(instanceUrl, orgUnit, parentModule);
+		let self = Array.isArray(items) && items.find(m => m.Type === 0 && m.Title === module.title);
+
+		if (self) {
+			await this._updateModule({ instanceUrl, orgUnit, module, lmsModule: self });
+		} else {
+			self = await this._createModule(instanceUrl, orgUnit, module, parentModule);
+		}
+
+		// Order matters on creates, so not using .map()
+		/* eslint-disable no-await-in-loop */
+		for (const child of module.children) {
+			switch (child.type) {
+				case 'module':
+					await this._processModule(instanceUrl, orgUnit, child, self);
+					break;
+				case 'quiz':
+					await this._quizProcessor.processQuiz(instanceUrl, orgUnit, child, self);
+					break;
+				case 'resource':
+					await this._processResource(instanceUrl, orgUnit, child, self);
+					break;
+				case 'topic':
+					await this._topicProcessor.processTopic({ instanceUrl, orgUnit, topic: child, parentModule: self });
+					break;
+				default:
+					throw new Error(`Unknown content type: ${child.type}`);
+			}
+		}
+		/* eslint-enable no-await-in-loop */
+	}
+
+	async _createModule(instanceUrl, orgUnit, module, parentModule) {
+		console.log(`Creating module: '${module.title}'`);
+
+		const url = parentModule
+			? new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Identifier}/content/modules/${parentModule.Id}/structure/`, instanceUrl)
+			: new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Identifier}/content/root/`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'POST');
+
+		const descriptionFileName = module.descriptionFileName.replace(this._markdownRegex, '.html');
+		const descriptionHtml = await fs.promises.readFile(`${this._contentPath}/${descriptionFileName}`);
+
+		if (this._dryRun) {
+			return DryRunFakeModule;
+		}
+
+		const description = ContentFactory.createRichText(descriptionHtml.toString('utf-8'), 'Html');
+
+		const createModule = ContentFactory.createModule({
+			title: module.title,
+			description,
+			dueDate: module.dueDate
+		});
+
+		const response = await this._fetch(
+			signedUrl,
+			{
+				method: 'POST',
+				body: JSON.stringify(createModule)
+			});
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return response.json();
+	}
+
+	async _updateModule({ instanceUrl, orgUnit, module, lmsModule, isHidden = false }) {
+		console.log(`Updating module: '${module.title}'`);
+
+		const url = new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Identifier}/content/modules/${lmsModule.Id}`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'PUT');
+
+		const descriptionFileName = module.descriptionFileName.replace(this._markdownRegex, '.html');
+		const descriptionHtml = await fs.promises.readFile(`${this._contentPath}/${descriptionFileName}`);
+
+		const description = ContentFactory.createRichText(descriptionHtml.toString('utf-8'), 'Html');
+
+		const body = {
+			...lmsModule,
+			...{
+				Title: module.title,
+				ShortTitle: module.title,
+				ModuleDueDate: module.dueDate || null,
+				IsHidden: isHidden,
+				Description: description
+			}
+		};
+
+		if (this._dryRun) {
+			return body;
+		}
+
+		const response = await this._fetch(
+			signedUrl,
+			{
+				method: 'PUT',
+				body: JSON.stringify(body)
+			});
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return body;
+	}
+
+	async _processResource(instanceUrl, orgUnit, resource, parentModule) {
+		const topic = {
+			...resource,
+			...{
+				title: resource.fileName
+			}
+		};
+
+		return this._topicProcessor.processTopic({ instanceUrl, orgUnit, topic, parentModule, isHidden: true });
+	}
+
+	async _getContent(instanceUrl, orgUnit, parentModule = null) {
+		const url = parentModule
+			? new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Identifier}/content/modules/${parentModule.Id}/structure/`, instanceUrl)
+			: new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Identifier}/content/root/`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'GET');
+
+		if (this._dryRun && parentModule.Id === DryRunFakeModule.Id) {
+			return DryRunFakeModule;
+		}
+
+		const response = await this._fetch(signedUrl);
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return response.json();
+	}
+};
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -518,9 +518,6 @@ module.exports = class QuizProcessor {
 	}
 
 	async processQuiz(instanceUrl, orgUnit, quiz, parentModule) {
-		const quizzes = await this._getQuizzes(instanceUrl, orgUnit);
-		const quizItem = quizzes.Objects && Array.isArray(quizzes.Objects) && quizzes.Objects.find(x => x.Name === quiz.title);
-
 		const content = await this._getContent(instanceUrl, orgUnit, parentModule);
 		const self = Array.isArray(content) && content.find(x => x.Type === 1 && x.TopicType === 3 && x.Title === quiz.title);
 
@@ -528,6 +525,9 @@ module.exports = class QuizProcessor {
 			// Nothing to do, the quicklink exists
 			return self;
 		}
+
+		const quizzes = await this._getQuizzes(instanceUrl, orgUnit);
+		const quizItem = quizzes.Objects && Array.isArray(quizzes.Objects) && quizzes.Objects.find(x => x.Name === quiz.title);
 
 		return this._createQuizTopic({ instanceUrl, orgUnit, quiz, parentModule, quizItem });
 	}
@@ -542,7 +542,8 @@ module.exports = class QuizProcessor {
 		const topic = ContentFactory.createTopic({
 			title: quiz.title,
 			topicType: 3,
-			url: `/d2l/common/dialogs/quickLink/quickLink.d2l?ou=${orgUnit.Id}&type=quiz&rcode=${rcode}`
+			url: `/d2l/common/dialogs/quickLink/quickLink.d2l?ou=${orgUnit.Id}&type=quiz&rcode=${rcode}`,
+			isExempt: !quiz.isRequired
 		});
 
 		if (this._dryRun) {

--- a/manifest_schema_v1_0.json
+++ b/manifest_schema_v1_0.json
@@ -35,6 +35,9 @@
                 "$ref": "#/definitions/module"
               },
               {
+                "$ref": "#/definitions/quiz"
+              },
+              {
                 "$ref": "#/definitions/resource"
               },
               {
@@ -48,6 +51,26 @@
         "title",
         "type",
         "children"
+      ]
+    },
+    "quiz": {
+      "type": "object",
+      "additionalItems": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "quiz"
+          ]
+        },
+        "title": {
+          "type": "string",
+          "title": "The name of the quiz"
+        }
+      },
+      "required": [
+        "title",
+        "type"
       ]
     },
     "resource": {

--- a/manifest_schema_v1_0.json
+++ b/manifest_schema_v1_0.json
@@ -66,6 +66,10 @@
         "title": {
           "type": "string",
           "title": "The name of the quiz"
+        },
+        "isRequired": {
+          "type": "boolean",
+          "title": "Indicates if the quiz is required for completion"
         }
       },
       "required": [

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+	DryRunFakeModule: {
+		Id: 0
+	},
+	LEVersion: '1.46',
+	LPVersion: '1.28'
+};

--- a/src/test/content/manifest.json
+++ b/src/test/content/manifest.json
@@ -14,6 +14,10 @@
           "isRequired": true
         },
         {
+          "title": "Test Quiz",
+          "type": "quiz"
+        },
+        {
           "type": "resource",
           "fileName": "test-module/resource.txt"
         }

--- a/src/test/upload-course-content.test.js
+++ b/src/test/upload-course-content.test.js
@@ -1,15 +1,13 @@
 'use strict';
 
 const path = require('path');
-
 const test = require('ava');
 const fetchMock = require('fetch-mock');
 
-const FormData = require('form-data');
 const UploadCourseContent = require('../upload-course-content');
 
-const contentDirectory = path.join(__dirname, 'content');
-const manifestPath = path.join(__dirname, 'content', '/manifest.json');
+const ContentPath = path.join(__dirname, 'content');
+const ManifestPath = path.join(__dirname, 'content/manifest.json');
 
 const MockValence = {
 	createAuthenticatedUrl(url) {
@@ -17,19 +15,25 @@ const MockValence = {
 	}
 };
 
-test('uploadCourseContent creates module, resource, and topic', async t => {
+const OrgUnit = {
+	Identifier: '123',
+	Name: 'Org Unit',
+	Path: '/content/course123/'
+};
+
+test('uploadCourseContent processes module', async t => {
 	const url = new URL('https://example.com');
 
 	const fetch = fetchMock.sandbox();
 	fetch.get({
-		url: 'https://example.com/d2l/api/lp/1.23/users/whoami'
+		url: 'https://example.com/d2l/api/lp/1.28/users/whoami'
 	}, {
 		body: {
 			UniqueName: 'Test User'
 		}
 	});
 	fetch.get({
-		url: 'https://example.com/d2l/api/lp/1.23/courses/123'
+		url: 'https://example.com/d2l/api/lp/1.28/courses/123'
 	}, {
 		body: {
 			Identifier: '123',
@@ -37,607 +41,35 @@ test('uploadCourseContent creates module, resource, and topic', async t => {
 			Path: '/content/course123/'
 		}
 	});
-	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.34/123/content/root/'
-	}, {
-		body: ''
-	});
-	fetch.post((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.34/123/content/root/') {
-			return false;
+
+	class MockModuleProcessor {
+		processModule(instanceUrl, orgUnit, module) {
+			t.is(instanceUrl.toString(), 'https://example.com/');
+			t.deepEqual(orgUnit, OrgUnit);
+			t.deepEqual(module, {
+				title: 'Test Module',
+				type: 'module',
+				descriptionFileName: 'test-module/index.md',
+				dueDate: '2020-01-01T00:00:00.000Z',
+				children: [{
+					title: 'Test Topic',
+					type: 'topic',
+					fileName: 'test-module/test-topic.md',
+					isRequired: true
+				},
+				{
+					title: 'Test Quiz',
+					type: 'quiz'
+				},
+				{
+					type: 'resource',
+					fileName: 'test-module/resource.txt'
+				}]
+			});
 		}
+	}
 
-		t.deepEqual(JSON.parse(options.body), {
-			Title: 'Test Module',
-			ShortTitle: 'Test Module',
-			Type: 0,
-			ModuleStartDate: null,
-			ModuleEndDate: null,
-			ModuleDueDate: '2020-01-01T00:00:00.000Z',
-			IsHidden: false,
-			IsLocked: false,
-			Description: {
-				Html: '<html></html>\n'
-			}
-		});
-
-		return true;
-	}, {
-		Id: 1,
-		ShortTitle: 'Test Module',
-		Type: 0,
-		ModuleStartDate: null,
-		ModuleEndDate: null,
-		ModuleDueDate: '2020-01-01T00:00:00.000Z',
-		IsHidden: false,
-		IsLocked: false,
-		Description: {
-			Html: '<html></html>\n'
-		}
-	});
-	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.34/123/content/modules/1/structure/'
-	}, {
-		body: ''
-	});
-	fetch.post((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.34/123/content/modules/1/structure/') {
-			return false;
-		}
-
-		const formdata = new FormData(options.body);
-		if (!formdata.getBuffer().toString('utf-8').includes('test-topic.html')) {
-			return false;
-		}
-
-		t.is(options.headers['Content-Type'], `multipart/mixed; boundary=${formdata.getBoundary()}`);
-
-		t.is(formdata.getBuffer().toString('utf-8'), `--${formdata.getBoundary()}\r\n`
-			+ 'Content-Disposition: form-data; name=""\r\n'
-			+ 'Content-Type: application/json\r\n\r\n'
-			+ '{"Title":"Test Topic","ShortTitle":"Test Topic","Type":1,"TopicType":1,"StartDate":null,"EndDate":null,"DueDate":null,"Url":"/content/course123/test-module/test-topic.html","IsHidden":false,"IsLocked":false,"IsExempt":false}\r\n'
-			+ `--${formdata.getBoundary()}\r\n`
-			+ 'Content-Disposition: form-data; name=""; filename="test-topic.html"\r\n'
-			+ 'Content-Type: text/html\r\n\r\n'
-			+ '<h1></h1>\n\r\n'
-			+ `--${formdata.getBoundary()}--\r\n`);
-
-		return true;
-	}, {
-		body: {
-			Id: 2,
-			Title: 'Test Topic',
-			Type: 1,
-			TopicType: 1,
-			StartDate: null,
-			EndDate: null,
-			DueDate: null,
-			IsHidden: false,
-			IsLocked: false,
-			IsExempt: false,
-			OpenAsExternalResource: false,
-			Description: {
-				Html: '<h1></h1>\n'
-			}
-		}
-	});
-	fetch.post((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.34/123/content/modules/1/structure/') {
-			return false;
-		}
-
-		const formdata = new FormData(options.body);
-		if (!formdata.getBuffer().toString('utf-8').includes('resource.txt')) {
-			return false;
-		}
-
-		t.is(options.headers['Content-Type'], `multipart/mixed; boundary=${formdata.getBoundary()}`);
-
-		t.is(formdata.getBuffer().toString('utf-8'), `--${formdata.getBoundary()}\r\n`
-			+ 'Content-Disposition: form-data; name=""\r\n'
-			+ 'Content-Type: application/json\r\n\r\n'
-			+ '{"Title":"test-module/resource.txt","ShortTitle":"test-module/resource.txt","Type":1,"TopicType":1,"StartDate":null,"EndDate":null,"DueDate":null,"Url":"/content/course123/test-module/resource.txt","IsHidden":true,"IsLocked":false,"IsExempt":true}\r\n'
-			+ `--${formdata.getBoundary()}\r\n`
-			+ 'Content-Disposition: form-data; name=""; filename="resource.txt"\r\n'
-			+ 'Content-Type: text/html\r\n\r\n'
-			+ 'ABC\n\r\n'
-			+ `--${formdata.getBoundary()}--\r\n`);
-
-		return true;
-	}, {
-		body: {
-			Id: 3,
-			Title: 'test-module/resource.txt',
-			Type: 1,
-			TopicType: 1,
-			StartDate: null,
-			EndDate: null,
-			DueDate: null,
-			IsHidden: false,
-			IsLocked: false,
-			IsExempt: true,
-			OpenAsExternalResource: false
-		}
-	});
-
-	const uploader = new UploadCourseContent({ contentDirectory, manifestPath, isDryRun: false }, MockValence, fetch);
-
-	await uploader.uploadCourseContent(url, 123);
-
-	t.true(fetch.done());
-});
-
-test('uploadCourseContent skips creation on dry run', async t => {
-	const url = new URL('https://example.com');
-
-	const fetch = fetchMock.sandbox();
-	fetch.get({
-		url: 'https://example.com/d2l/api/lp/1.23/users/whoami'
-	}, {
-		body: {
-			UniqueName: 'Test User'
-		}
-	});
-	fetch.get({
-		url: 'https://example.com/d2l/api/lp/1.23/courses/123'
-	}, {
-		body: {
-			Identifier: '123',
-			Name: 'Org Unit',
-			Path: '/content/course123/'
-		}
-	});
-	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.34/123/content/root/'
-	}, {
-		body: ''
-	});
-	fetch.get({
-		url: `https://example.com/d2l/api/le/1.34/123/content/modules/${UploadCourseContent.DRY_RUN_FAKE_MODULE.Id}/structure/`
-	}, {
-		body: ''
-	});
-
-	const uploader = new UploadCourseContent({ contentDirectory, manifestPath, isDryRun: true }, MockValence, fetch);
-
-	await uploader.uploadCourseContent(url, 123);
-
-	t.true(fetch.done());
-});
-
-test('uploadCourseContent updates module, creates resource and topic', async t => {
-	const url = new URL('https://example.com');
-
-	const fetch = fetchMock.sandbox();
-	fetch.get({
-		url: 'https://example.com/d2l/api/lp/1.23/users/whoami'
-	}, {
-		body: {
-			UniqueName: 'Test User'
-		}
-	});
-	fetch.get({
-		url: 'https://example.com/d2l/api/lp/1.23/courses/123'
-	}, {
-		body: {
-			Identifier: '123',
-			Name: 'Org Unit',
-			Path: '/content/course123/'
-		}
-	});
-	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.34/123/content/root/'
-	}, {
-		body: [{
-			Id: 1,
-			Type: 0,
-			Title: 'Test Module',
-			ModuleStartDate: null,
-			ModuleEndDate: null,
-			ModuleDueDate: null,
-			IsHidden: false,
-			IsLocked: false,
-			Description: {
-				Html: '<h1></h1>\n'
-			}
-		}]
-	});
-	fetch.put((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.34/123/content/modules/1') {
-			return false;
-		}
-
-		t.deepEqual(JSON.parse(options.body), {
-			Id: 1,
-			Title: 'Test Module',
-			ShortTitle: 'Test Module',
-			Type: 0,
-			ModuleStartDate: null,
-			ModuleEndDate: null,
-			ModuleDueDate: '2020-01-01T00:00:00.000Z',
-			IsHidden: false,
-			IsLocked: false,
-			Description: {
-				Html: '<html></html>\n'
-			}
-		});
-
-		return true;
-	}, {
-		status: 200
-	});
-	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.34/123/content/modules/1/structure/'
-	}, {
-		body: ''
-	});
-	fetch.post((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.34/123/content/modules/1/structure/') {
-			return false;
-		}
-
-		const formdata = new FormData(options.body);
-		if (!formdata.getBuffer().toString('utf-8').includes('test-topic.html')) {
-			return false;
-		}
-
-		t.is(formdata.getBuffer().toString('utf-8'), `--${formdata.getBoundary()}\r\n`
-			+ 'Content-Disposition: form-data; name=""\r\n'
-			+ 'Content-Type: application/json\r\n\r\n'
-			+ '{"Title":"Test Topic","ShortTitle":"Test Topic","Type":1,"TopicType":1,"StartDate":null,"EndDate":null,"DueDate":null,"Url":"/content/course123/test-module/test-topic.html","IsHidden":false,"IsLocked":false,"IsExempt":false}\r\n'
-			+ `--${formdata.getBoundary()}\r\n`
-			+ 'Content-Disposition: form-data; name=""; filename="test-topic.html"\r\n'
-			+ 'Content-Type: text/html\r\n\r\n'
-			+ '<h1></h1>\n\r\n'
-			+ `--${formdata.getBoundary()}--\r\n`);
-
-		return true;
-	}, {
-		body: {
-			Id: 2,
-			Title: 'Test Topic',
-			ShortTitle: 'Test Topic',
-			Type: 1,
-			TopicType: 1,
-			StartDate: null,
-			EndDate: null,
-			DueDate: null,
-			IsHidden: false,
-			IsLocked: false,
-			IsExempt: false,
-			OpenAsExternalResource: false
-		}
-	});
-	fetch.post((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.34/123/content/modules/1/structure/') {
-			return false;
-		}
-
-		const formdata = new FormData(options.body);
-		if (!formdata.getBuffer().toString('utf-8').includes('resource.txt')) {
-			return false;
-		}
-
-		t.is(formdata.getBuffer().toString('utf-8'), `--${formdata.getBoundary()}\r\n`
-			+ 'Content-Disposition: form-data; name=""\r\n'
-			+ 'Content-Type: application/json\r\n\r\n'
-			+ '{"Title":"test-module/resource.txt","ShortTitle":"test-module/resource.txt","Type":1,"TopicType":1,"StartDate":null,"EndDate":null,"DueDate":null,"Url":"/content/course123/test-module/resource.txt","IsHidden":true,"IsLocked":false,"IsExempt":true}\r\n'
-			+ `--${formdata.getBoundary()}\r\n`
-			+ 'Content-Disposition: form-data; name=""; filename="resource.txt"\r\n'
-			+ 'Content-Type: text/html\r\n\r\n'
-			+ 'ABC\n\r\n'
-			+ `--${formdata.getBoundary()}--\r\n`);
-
-		return true;
-	}, {
-		body: {
-			Id: 3,
-			Title: 'test-module/resource.txt',
-			ShortTitle: 'test-module/resource.txt',
-			Type: 1,
-			TopicType: 1,
-			StartDate: null,
-			EndDate: null,
-			DueDate: null,
-			IsHidden: false,
-			IsLocked: false,
-			IsExempt: true,
-			OpenAsExternalResource: false
-		}
-	});
-
-	const uploader = new UploadCourseContent({ contentDirectory, manifestPath, isDryRun: false }, MockValence, fetch);
-
-	await uploader.uploadCourseContent(url, 123);
-
-	t.true(fetch.done());
-});
-
-test('uploadCourseContent updates module, resource, and topic', async t => {
-	const url = new URL('https://example.com');
-
-	const fetch = fetchMock.sandbox();
-	fetch.get({
-		url: 'https://example.com/d2l/api/lp/1.23/users/whoami'
-	}, {
-		body: {
-			UniqueName: 'Test User'
-		}
-	});
-	fetch.get({
-		url: 'https://example.com/d2l/api/lp/1.23/courses/123'
-	}, {
-		body: {
-			Identifier: '123',
-			Name: 'Org Unit',
-			Path: '/content/course123/'
-		}
-	});
-	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.34/123/content/root/'
-	}, {
-		body: [{
-			Id: 1,
-			Title: 'Test Module',
-			ShortTitle: 'Test Module',
-			Type: 0,
-			ModuleStartDate: null,
-			ModuleEndDate: null,
-			ModuleDueDate: null,
-			IsHidden: false,
-			IsLocked: false,
-			Description: {
-				Html: '<h2></h2>\n'
-			}
-		}]
-	});
-	fetch.put((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.34/123/content/modules/1') {
-			return false;
-		}
-
-		t.deepEqual(JSON.parse(options.body), {
-			Id: 1,
-			Title: 'Test Module',
-			ShortTitle: 'Test Module',
-			Type: 0,
-			ModuleStartDate: null,
-			ModuleEndDate: null,
-			ModuleDueDate: '2020-01-01T00:00:00.000Z',
-			IsHidden: false,
-			IsLocked: false,
-			Description: {
-				Html: '<html></html>\n'
-			}
-		});
-
-		return true;
-	}, {
-		status: 200
-	});
-	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.34/123/content/modules/1/structure/'
-	}, {
-		body: [{
-			Id: 2,
-			Title: 'Test Topic',
-			ShortTitle: 'Test Topic',
-			Type: 1,
-			TopicType: 1,
-			DueDate: null,
-			StartDate: null,
-			EndDate: null,
-			IsHidden: false,
-			IsLocked: false,
-			IsExempt: false,
-			OpenAsExternalResource: false
-		}, {
-			Id: 3,
-			Title: 'test-module/resource.txt',
-			ShortTitle: 'test-module/resource.txt',
-			Type: 1,
-			TopicType: 1,
-			DueDate: null,
-			StartDate: null,
-			EndDate: null,
-			IsHidden: true,
-			IsLocked: false,
-			IsExempt: true,
-			OpenAsExternalResource: false
-		}]
-	});
-	fetch.put((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.34/123/content/topics/2') {
-			return false;
-		}
-
-		t.deepEqual(JSON.parse(options.body), {
-			Id: 2,
-			Title: 'Test Topic',
-			ShortTitle: 'Test Topic',
-			Type: 1,
-			TopicType: 1,
-			StartDate: null,
-			EndDate: null,
-			DueDate: null,
-			IsHidden: false,
-			IsLocked: false,
-			IsExempt: false,
-			OpenAsExternalResource: false,
-			ResetCompletionTracking: true,
-			Url: '/content/course123/test-module/test-topic.html'
-		});
-
-		return true;
-	}, {
-		body: {
-			Id: 2,
-			Title: 'Test Topic',
-			Type: 1,
-			TopicType: 1,
-			StartDate: null,
-			EndDate: null,
-			DueDate: null,
-			IsHidden: false,
-			IsLocked: false,
-			IsExempt: false,
-			OpenAsExternalResource: false
-		}
-	});
-	fetch.put((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.34/123/content/topics/2/file') {
-			return false;
-		}
-
-		const formdata = new FormData(options.body);
-		t.is(formdata.getBuffer().toString('utf-8'), `--${formdata.getBoundary()}\r\n`
-			+ 'Content-Disposition: form-data; name="file"; filename="test-topic.html"\r\n'
-			+ 'Content-Type: text/html\r\n\r\n'
-			+ '<h1></h1>\n\r\n'
-			+ `--${formdata.getBoundary()}--\r\n`);
-
-		return true;
-	}, {
-		status: 200
-	});
-	fetch.put((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.34/123/content/topics/3') {
-			return false;
-		}
-
-		if (!options.body.includes('resource.txt')) {
-			return false;
-		}
-
-		t.deepEqual(JSON.parse(options.body), {
-			Id: 3,
-			Title: 'test-module/resource.txt',
-			ShortTitle: 'test-module/resource.txt',
-			Type: 1,
-			TopicType: 1,
-			StartDate: null,
-			EndDate: null,
-			DueDate: null,
-			IsHidden: true,
-			IsLocked: false,
-			IsExempt: true,
-			OpenAsExternalResource: false,
-			ResetCompletionTracking: true,
-			Url: '/content/course123/test-module/resource.txt'
-		});
-
-		return true;
-	}, {
-		body: {
-			Id: 3,
-			Title: 'test-module/resource.txt',
-			ShortTitle: 'test-module/resource.txt',
-			Type: 1,
-			TopicType: 1,
-			StartDate: null,
-			EndDate: null,
-			DueDate: null,
-			IsHidden: true,
-			IsLocked: false,
-			IsExempt: true,
-			OpenAsExternalResource: false
-		}
-	});
-	fetch.put((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.34/123/content/topics/3/file') {
-			return false;
-		}
-
-		const formdata = new FormData(options.body);
-		t.is(formdata.getBuffer().toString('utf-8'), `--${formdata.getBoundary()}\r\n`
-			+ 'Content-Disposition: form-data; name="file"; filename="resource.txt"\r\n'
-			+ 'Content-Type: text/html\r\n\r\n'
-			+ 'ABC\n\r\n'
-			+ `--${formdata.getBoundary()}--\r\n`);
-
-		return true;
-	}, {
-		status: 200
-	});
-
-	const uploader = new UploadCourseContent({ contentDirectory, manifestPath, isDryRun: false }, MockValence, fetch);
-
-	await uploader.uploadCourseContent(url, 123);
-
-	t.true(fetch.done());
-});
-
-test('uploadCourseContent skips updates on dry run', async t => {
-	const url = new URL('https://example.com');
-
-	const fetch = fetchMock.sandbox();
-	fetch.get({
-		url: 'https://example.com/d2l/api/lp/1.23/users/whoami'
-	}, {
-		body: {
-			UniqueName: 'Test User'
-		}
-	});
-	fetch.get({
-		url: 'https://example.com/d2l/api/lp/1.23/courses/123'
-	}, {
-		body: {
-			Identifier: '123',
-			Name: 'Org Unit',
-			Path: '/content/course123/'
-		}
-	});
-	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.34/123/content/root/'
-	}, {
-		body: [{
-			Id: 1,
-			Title: 'Test Module',
-			ShortTitle: 'Test Module',
-			Type: 0,
-			ModuleStartDate: null,
-			ModuleEndDate: null,
-			ModuleDueDate: null,
-			IsHidden: false,
-			IsLocked: false,
-			Description: {
-				Html: '<h2></h2>\n'
-			}
-		}]
-	});
-	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.34/123/content/modules/1/structure/'
-	}, {
-		body: [{
-			Id: 2,
-			Title: 'Test Topic',
-			ShortTitle: 'Test Topic',
-			Type: 1,
-			TopicType: 1,
-			DueDate: null,
-			StartDate: null,
-			EndDate: null,
-			IsHidden: false,
-			IsLocked: false,
-			IsExempt: false,
-			OpenAsExternalResource: false
-		}, {
-			Id: 3,
-			Title: 'test-module/resource.txt',
-			ShortTitle: 'test-module/resource.txt',
-			Type: 1,
-			TopicType: 1,
-			DueDate: null,
-			StartDate: null,
-			EndDate: null,
-			IsHidden: true,
-			IsLocked: false,
-			IsExempt: true,
-			OpenAsExternalResource: false
-		}]
-	});
-
-	const uploader = new UploadCourseContent({ contentDirectory, manifestPath, isDryRun: true }, MockValence, fetch);
+	const uploader = new UploadCourseContent({ contentDirectory: ContentPath, manifestPath: ManifestPath }, MockValence, { fetch, ModuleProcessor: MockModuleProcessor });
 
 	await uploader.uploadCourseContent(url, 123);
 

--- a/src/test/utility/module-processor.test.js
+++ b/src/test/utility/module-processor.test.js
@@ -1,0 +1,628 @@
+'use strict';
+
+const fetchMock = require('fetch-mock');
+const path = require('path');
+const test = require('ava');
+
+const ModuleProcessor = require('../../utility/module-processor');
+
+const ContentPath = path.join(__dirname, '..', 'content');
+
+const MockValence = {
+	createAuthenticatedUrl(url) {
+		return url;
+	}
+};
+
+const OrgUnit = {
+	Identifier: '123',
+	Name: 'Org Unit',
+	Path: '/content/course123/'
+};
+
+const TestModule = {
+	title: 'Test Module',
+	type: 'module',
+	descriptionFileName: 'test-module/index.md',
+	dueDate: '2020-01-01T00:00:00.000Z',
+	children: [
+		{
+			title: 'Test Topic',
+			type: 'topic',
+			fileName: 'test-module/test-topic.md',
+			isRequired: true
+		},
+		{
+			title: 'Test Quiz',
+			type: 'quiz'
+		},
+		{
+			type: 'resource',
+			fileName: 'test-module/resource.txt'
+		}
+	]
+};
+
+test('creates module', async t => {
+	const url = new URL('https://example.com');
+
+	const fetch = fetchMock.sandbox();
+	fetch.get({
+		url: 'https://example.com/d2l/api/le/1.46/123/content/root/'
+	}, {
+		body: ''
+	});
+	fetch.post((url, options) => {
+		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/root/') {
+			return false;
+		}
+
+		t.deepEqual(JSON.parse(options.body), {
+			Title: 'Test Module',
+			ShortTitle: 'Test Module',
+			Type: 0,
+			ModuleStartDate: null,
+			ModuleEndDate: null,
+			ModuleDueDate: '2020-01-01T00:00:00.000Z',
+			IsHidden: false,
+			IsLocked: false,
+			Description: {
+				Content: '<html></html>\n',
+				Type: 'Html'
+			}
+		});
+
+		return true;
+	}, {
+		Id: 1,
+		Title: 'Test Module',
+		ShortTitle: 'Test Module',
+		Type: 0,
+		ModuleStartDate: null,
+		ModuleEndDate: null,
+		ModuleDueDate: '2020-01-01T00:00:00.000Z',
+		IsHidden: false,
+		IsLocked: false,
+		Description: {
+			Html: '<html></html>\n'
+		}
+	});
+
+	class MockTopicProcessor {
+		processTopic({ instanceUrl, orgUnit, topic, parentModule, isHidden = false }) {
+			t.is(instanceUrl.toString(), 'https://example.com/');
+			t.deepEqual(orgUnit, OrgUnit);
+			if (topic.title === 'Test Topic') {
+				t.deepEqual(topic, {
+					title: 'Test Topic',
+					type: 'topic',
+					fileName: 'test-module/test-topic.md',
+					isRequired: true
+				});
+				t.is(isHidden, false);
+			} else {
+				t.deepEqual(topic, {
+					title: 'test-module/resource.txt',
+					type: 'resource',
+					fileName: 'test-module/resource.txt'
+				});
+				t.is(isHidden, true);
+			}
+
+			t.deepEqual(parentModule, {
+				Id: 1,
+				Title: 'Test Module',
+				ShortTitle: 'Test Module',
+				Type: 0,
+				ModuleStartDate: null,
+				ModuleEndDate: null,
+				ModuleDueDate: '2020-01-01T00:00:00.000Z',
+				IsHidden: false,
+				IsLocked: false,
+				Description: {
+					Html: '<html></html>\n'
+				}
+			});
+		}
+	}
+
+	class MockQuizProcessor {
+		processQuiz(instanceUrl, orgUnit, quiz, parentModule) {
+			t.is(instanceUrl.toString(), 'https://example.com/');
+			t.deepEqual(orgUnit, OrgUnit);
+			t.deepEqual(quiz, {
+				title: 'Test Quiz',
+				type: 'quiz'
+			});
+			t.deepEqual(parentModule, {
+				Id: 1,
+				Title: 'Test Module',
+				ShortTitle: 'Test Module',
+				Type: 0,
+				ModuleStartDate: null,
+				ModuleEndDate: null,
+				ModuleDueDate: '2020-01-01T00:00:00.000Z',
+				IsHidden: false,
+				IsLocked: false,
+				Description: {
+					Html: '<html></html>\n'
+				}
+			});
+		}
+	}
+
+	const processor = new ModuleProcessor({ contentPath: ContentPath }, MockValence, { fetch, TopicProcessor: MockTopicProcessor, QuizProcessor: MockQuizProcessor });
+
+	await processor.processModule(url, OrgUnit, TestModule);
+
+	t.true(fetch.done());
+});
+
+test('updates module', async t => {
+	const url = new URL('https://example.com');
+
+	const fetch = fetchMock.sandbox();
+	fetch.get({
+		url: 'https://example.com/d2l/api/le/1.46/123/content/root/'
+	}, {
+		body: [{
+			Id: 1,
+			Type: 0,
+			Title: 'Test Module',
+			ShortTitle: 'Test Module',
+			ModuleStartDate: null,
+			ModuleEndDate: null,
+			ModuleDueDate: '2020-01-01T00:00:00.000Z',
+			IsHidden: false,
+			IsLocked: false,
+			Description: {
+				Html: '<html></html>\n'
+			}
+		}]
+	});
+	fetch.put((url, options) => {
+		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/modules/1') {
+			return false;
+		}
+
+		t.deepEqual(JSON.parse(options.body), {
+			Id: 1,
+			Title: 'Test Module',
+			ShortTitle: 'Test Module',
+			Type: 0,
+			ModuleStartDate: null,
+			ModuleEndDate: null,
+			ModuleDueDate: '2020-01-01T00:00:00.000Z',
+			IsHidden: false,
+			IsLocked: false,
+			Description: {
+				Content: '<html></html>\n',
+				Type: 'Html'
+			}
+		});
+
+		return true;
+	}, {
+		status: 200
+	});
+
+	class MockTopicProcessor {
+		processTopic({ instanceUrl, orgUnit, topic, parentModule, isHidden = false }) {
+			t.is(instanceUrl.toString(), 'https://example.com/');
+			t.deepEqual(orgUnit, OrgUnit);
+			if (topic.title === 'Test Topic') {
+				t.deepEqual(topic, {
+					title: 'Test Topic',
+					type: 'topic',
+					fileName: 'test-module/test-topic.md',
+					isRequired: true
+				});
+				t.is(isHidden, false);
+			} else {
+				t.deepEqual(topic, {
+					title: 'test-module/resource.txt',
+					type: 'resource',
+					fileName: 'test-module/resource.txt'
+				});
+				t.is(isHidden, true);
+			}
+
+			t.deepEqual(parentModule, {
+				Id: 1,
+				Title: 'Test Module',
+				ShortTitle: 'Test Module',
+				Type: 0,
+				ModuleStartDate: null,
+				ModuleEndDate: null,
+				ModuleDueDate: '2020-01-01T00:00:00.000Z',
+				IsHidden: false,
+				IsLocked: false,
+				Description: {
+					Html: '<html></html>\n'
+				}
+			});
+		}
+	}
+
+	class MockQuizProcessor {
+		processQuiz(instanceUrl, orgUnit, quiz, parentModule) {
+			t.is(instanceUrl.toString(), 'https://example.com/');
+			t.deepEqual(orgUnit, OrgUnit);
+			t.deepEqual(quiz, {
+				title: 'Test Quiz',
+				type: 'quiz'
+			});
+			t.deepEqual(parentModule, {
+				Id: 1,
+				Title: 'Test Module',
+				ShortTitle: 'Test Module',
+				Type: 0,
+				ModuleStartDate: null,
+				ModuleEndDate: null,
+				ModuleDueDate: '2020-01-01T00:00:00.000Z',
+				IsHidden: false,
+				IsLocked: false,
+				Description: {
+					Html: '<html></html>\n'
+				}
+			});
+		}
+	}
+
+	const processor = new ModuleProcessor({ contentPath: ContentPath }, MockValence, { fetch, TopicProcessor: MockTopicProcessor, QuizProcessor: MockQuizProcessor });
+
+	await processor.processModule(url, OrgUnit, TestModule);
+
+	t.true(fetch.done());
+});
+
+test('creates submodule', async t => {
+	const url = new URL('https://example.com');
+
+	const fetch = fetchMock.sandbox();
+	fetch.get({
+		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
+	}, {
+		body: [{
+			Id: 1,
+			Type: 0,
+			Title: 'Parent Module',
+			ShortTitle: 'Parent Module',
+			ModuleStartDate: null,
+			ModuleEndDate: null,
+			ModuleDueDate: '2020-01-01T00:00:00.000Z',
+			IsHidden: false,
+			IsLocked: false,
+			Description: {
+				Html: '<html></html>\n'
+			}
+		}]
+	});
+	fetch.post((url, options) => {
+		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/') {
+			return false;
+		}
+
+		t.deepEqual(JSON.parse(options.body), {
+			Title: 'Test Module',
+			ShortTitle: 'Test Module',
+			Type: 0,
+			ModuleStartDate: null,
+			ModuleEndDate: null,
+			ModuleDueDate: '2020-01-01T00:00:00.000Z',
+			IsHidden: false,
+			IsLocked: false,
+			Description: {
+				Content: '<html></html>\n',
+				Type: 'Html'
+			}
+		});
+
+		return true;
+	}, {
+		Id: 2,
+		Title: 'Test Module',
+		ShortTitle: 'Test Module',
+		Type: 0,
+		ModuleStartDate: null,
+		ModuleEndDate: null,
+		ModuleDueDate: '2020-01-01T00:00:00.000Z',
+		IsHidden: false,
+		IsLocked: false,
+		Description: {
+			Html: '<html></html>\n'
+		}
+	});
+
+	class MockTopicProcessor {
+		processTopic({ instanceUrl, orgUnit, topic, parentModule, isHidden = false }) {
+			t.is(instanceUrl.toString(), 'https://example.com/');
+			t.deepEqual(orgUnit, OrgUnit);
+			if (topic.title === 'Test Topic') {
+				t.deepEqual(topic, {
+					title: 'Test Topic',
+					type: 'topic',
+					fileName: 'test-module/test-topic.md',
+					isRequired: true
+				});
+				t.is(isHidden, false);
+			} else {
+				t.deepEqual(topic, {
+					title: 'test-module/resource.txt',
+					type: 'resource',
+					fileName: 'test-module/resource.txt'
+				});
+				t.is(isHidden, true);
+			}
+
+			t.deepEqual(parentModule, {
+				Id: 2,
+				Title: 'Test Module',
+				ShortTitle: 'Test Module',
+				Type: 0,
+				ModuleStartDate: null,
+				ModuleEndDate: null,
+				ModuleDueDate: '2020-01-01T00:00:00.000Z',
+				IsHidden: false,
+				IsLocked: false,
+				Description: {
+					Html: '<html></html>\n'
+				}
+			});
+		}
+	}
+
+	class MockQuizProcessor {
+		processQuiz(instanceUrl, orgUnit, quiz, parentModule) {
+			t.is(instanceUrl.toString(), 'https://example.com/');
+			t.deepEqual(orgUnit, OrgUnit);
+			t.deepEqual(quiz, {
+				title: 'Test Quiz',
+				type: 'quiz'
+			});
+			t.deepEqual(parentModule, {
+				Id: 2,
+				Title: 'Test Module',
+				ShortTitle: 'Test Module',
+				Type: 0,
+				ModuleStartDate: null,
+				ModuleEndDate: null,
+				ModuleDueDate: '2020-01-01T00:00:00.000Z',
+				IsHidden: false,
+				IsLocked: false,
+				Description: {
+					Html: '<html></html>\n'
+				}
+			});
+		}
+	}
+
+	const processor = new ModuleProcessor({ contentPath: ContentPath }, MockValence, { fetch, TopicProcessor: MockTopicProcessor, QuizProcessor: MockQuizProcessor });
+
+	await processor.processModule(url, OrgUnit, TestModule, {
+		Id: 1,
+		Type: 0,
+		Title: 'Parent Module',
+		ShortTitle: 'Parent Module',
+		ModuleStartDate: null,
+		ModuleEndDate: null,
+		ModuleDueDate: '2020-01-01T00:00:00.000Z',
+		IsHidden: false,
+		IsLocked: false,
+		Description: {
+			Html: '<html></html>\n'
+		}
+	});
+
+	t.true(fetch.done());
+});
+
+test('updates submodule', async t => {
+	const url = new URL('https://example.com');
+
+	const fetch = fetchMock.sandbox();
+	fetch.get({
+		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
+	}, {
+		body: [{
+			Id: 1,
+			Type: 0,
+			Title: 'Parent Module',
+			ShortTitle: 'Parent Module',
+			ModuleStartDate: null,
+			ModuleEndDate: null,
+			ModuleDueDate: '2020-01-01T00:00:00.000Z',
+			IsHidden: false,
+			IsLocked: false,
+			Description: {
+				Html: '<html></html>\n'
+			}
+		}, {
+			Id: 2,
+			Title: 'Test Module',
+			ShortTitle: 'Test Module',
+			Type: 0,
+			ModuleStartDate: null,
+			ModuleEndDate: null,
+			ModuleDueDate: '2020-01-01T00:00:00.000Z',
+			IsHidden: false,
+			IsLocked: false,
+			Description: {
+				Html: '<html></html>\n'
+			}
+		}]
+	});
+	fetch.put((url, options) => {
+		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/modules/2') {
+			return false;
+		}
+
+		t.deepEqual(JSON.parse(options.body), {
+			Id: 2,
+			Title: 'Test Module',
+			ShortTitle: 'Test Module',
+			Type: 0,
+			ModuleStartDate: null,
+			ModuleEndDate: null,
+			ModuleDueDate: '2020-01-01T00:00:00.000Z',
+			IsHidden: false,
+			IsLocked: false,
+			Description: {
+				Content: '<html></html>\n',
+				Type: 'Html'
+			}
+		});
+
+		return true;
+	}, {
+		Id: 2,
+		Title: 'Test Module',
+		ShortTitle: 'Test Module',
+		Type: 0,
+		ModuleStartDate: null,
+		ModuleEndDate: null,
+		ModuleDueDate: '2020-01-01T00:00:00.000Z',
+		IsHidden: false,
+		IsLocked: false,
+		Description: {
+			Html: '<html></html>\n'
+		}
+	});
+
+	class MockTopicProcessor {
+		processTopic({ instanceUrl, orgUnit, topic, parentModule, isHidden = false }) {
+			t.is(instanceUrl.toString(), 'https://example.com/');
+			t.deepEqual(orgUnit, OrgUnit);
+			if (topic.title === 'Test Topic') {
+				t.deepEqual(topic, {
+					title: 'Test Topic',
+					type: 'topic',
+					fileName: 'test-module/test-topic.md',
+					isRequired: true
+				});
+				t.is(isHidden, false);
+			} else {
+				t.deepEqual(topic, {
+					title: 'test-module/resource.txt',
+					type: 'resource',
+					fileName: 'test-module/resource.txt'
+				});
+				t.is(isHidden, true);
+			}
+
+			t.deepEqual(parentModule, {
+				Id: 2,
+				Title: 'Test Module',
+				ShortTitle: 'Test Module',
+				Type: 0,
+				ModuleStartDate: null,
+				ModuleEndDate: null,
+				ModuleDueDate: '2020-01-01T00:00:00.000Z',
+				IsHidden: false,
+				IsLocked: false,
+				Description: {
+					Html: '<html></html>\n'
+				}
+			});
+		}
+	}
+
+	class MockQuizProcessor {
+		processQuiz(instanceUrl, orgUnit, quiz, parentModule) {
+			t.is(instanceUrl.toString(), 'https://example.com/');
+			t.deepEqual(orgUnit, OrgUnit);
+			t.deepEqual(quiz, {
+				title: 'Test Quiz',
+				type: 'quiz'
+			});
+			t.deepEqual(parentModule, {
+				Id: 2,
+				Title: 'Test Module',
+				ShortTitle: 'Test Module',
+				Type: 0,
+				ModuleStartDate: null,
+				ModuleEndDate: null,
+				ModuleDueDate: '2020-01-01T00:00:00.000Z',
+				IsHidden: false,
+				IsLocked: false,
+				Description: {
+					Html: '<html></html>\n'
+				}
+			});
+		}
+	}
+
+	const processor = new ModuleProcessor({ contentPath: ContentPath }, MockValence, { fetch, TopicProcessor: MockTopicProcessor, QuizProcessor: MockQuizProcessor });
+
+	await processor.processModule(url, OrgUnit, TestModule, {
+		Id: 1,
+		Type: 0,
+		Title: 'Parent Module',
+		ShortTitle: 'Parent Module',
+		ModuleStartDate: null,
+		ModuleEndDate: null,
+		ModuleDueDate: '2020-01-01T00:00:00.000Z',
+		IsHidden: false,
+		IsLocked: false,
+		Description: {
+			Html: '<html></html>\n'
+		}
+	});
+
+	t.true(fetch.done());
+});
+
+test('creates submodule, dryrun parentModule does not exist', async t => {
+	const url = new URL('https://example.com');
+
+	const fetch = fetchMock.sandbox();
+
+	class MockTopicProcessor {
+		processTopic({ instanceUrl, orgUnit, topic, parentModule, isHidden = false }) {
+			t.is(instanceUrl.toString(), 'https://example.com/');
+			t.deepEqual(orgUnit, OrgUnit);
+			if (topic.title === 'Test Topic') {
+				t.deepEqual(topic, {
+					title: 'Test Topic',
+					type: 'topic',
+					fileName: 'test-module/test-topic.md',
+					isRequired: true
+				});
+				t.is(isHidden, false);
+			} else {
+				t.deepEqual(topic, {
+					title: 'test-module/resource.txt',
+					type: 'resource',
+					fileName: 'test-module/resource.txt'
+				});
+				t.is(isHidden, true);
+			}
+
+			t.deepEqual(parentModule, {
+				Id: 0
+			});
+		}
+	}
+
+	class MockQuizProcessor {
+		processQuiz(instanceUrl, orgUnit, quiz, parentModule) {
+			t.is(instanceUrl.toString(), 'https://example.com/');
+			t.deepEqual(orgUnit, OrgUnit);
+			t.deepEqual(quiz, {
+				title: 'Test Quiz',
+				type: 'quiz'
+			});
+			t.deepEqual(parentModule, {
+				Id: 0
+			});
+		}
+	}
+
+	const processor = new ModuleProcessor({ contentPath: ContentPath, isDryRun: true }, MockValence, { fetch, TopicProcessor: MockTopicProcessor, QuizProcessor: MockQuizProcessor });
+
+	await processor.processModule(url, OrgUnit, TestModule, {
+		Id: 0
+	});
+
+	t.true(fetch.done());
+});

--- a/src/test/utility/quiz-processor.test.js
+++ b/src/test/utility/quiz-processor.test.js
@@ -89,7 +89,8 @@ test('creates quiz topic', async t => {
 
 	const quiz = {
 		title: 'Test Quiz',
-		type: 'quiz'
+		type: 'quiz',
+		isRequired: true
 	};
 
 	const processor = new QuizProcessor({}, MockValence, fetch);
@@ -102,15 +103,6 @@ test('noop on existing quiz topic', async t => {
 	const url = new URL('https://example.com');
 	const fetch = fetchMock.sandbox();
 
-	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.46/123/quizzes/'
-	}, {
-		Objects: [{
-			QuizId: 1,
-			Name: 'Test Quiz',
-			ActivityId: 'https://ids.brightspace.com/activities/quiz/Dev-1'
-		}]
-	});
 	fetch.get({
 		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
 	}, {

--- a/src/test/utility/quiz-processor.test.js
+++ b/src/test/utility/quiz-processor.test.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const test = require('ava');
+const fetchMock = require('fetch-mock');
+
+const QuizProcessor = require('../../utility/quiz-processor');
+
+const MockValence = {
+	createAuthenticatedUrl(url) {
+		return url;
+	}
+};
+
+const OrgUnit = {
+	Id: 123,
+	Name: 'Org Unit',
+	Path: '/content/course123/'
+};
+
+const ParentModule = {
+	Id: 1,
+	Title: 'Test Module',
+	ShortTitle: 'Test Module',
+	Type: 0,
+	ModuleStartDate: null,
+	ModuleEndDate: null,
+	ModuleDueDate: '2020-01-01T00:00:00.000Z',
+	IsHidden: false,
+	IsLocked: false,
+	Description: {
+		Html: '<html></html>\n'
+	}
+};
+
+test('creates quiz topic', async t => {
+	const url = new URL('https://example.com');
+	const fetch = fetchMock.sandbox();
+
+	fetch.get({
+		url: 'https://example.com/d2l/api/le/1.46/123/quizzes/'
+	}, {
+		Objects: [{
+			QuizId: 1,
+			Name: 'Test Quiz',
+			ActivityId: 'https://ids.brightspace.com/activities/quiz/Dev-1'
+		}]
+	});
+	fetch.get({
+		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
+	}, {
+		body: []
+	});
+	fetch.post((url, options) => {
+		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/') {
+			return false;
+		}
+
+		t.deepEqual(JSON.parse(options.body), {
+			Title: 'Test Quiz',
+			ShortTitle: 'Test Quiz',
+			Type: 1,
+			TopicType: 3,
+			Url: '/d2l/common/dialogs/quickLink/quickLink.d2l?ou=123&type=quiz&rcode=Dev-1',
+			StartDate: null,
+			EndDate: null,
+			DueDate: null,
+			IsHidden: false,
+			IsLocked: false,
+			IsExempt: false
+		});
+
+		return true;
+	}, {
+		body: {
+			Id: 2,
+			Title: 'Test Topic',
+			ShortTitle: 'Test Topic',
+			Type: 1,
+			TopicType: 1,
+			StartDate: null,
+			EndDate: null,
+			DueDate: null,
+			IsHidden: false,
+			IsLocked: false,
+			IsExempt: false,
+			OpenAsExternalResource: false
+		}
+	});
+
+	const quiz = {
+		title: 'Test Quiz',
+		type: 'quiz'
+	};
+
+	const processor = new QuizProcessor({}, MockValence, fetch);
+	await processor.processQuiz(url, OrgUnit, quiz, ParentModule);
+
+	t.true(fetch.done());
+});
+
+test('noop on existing quiz topic', async t => {
+	const url = new URL('https://example.com');
+	const fetch = fetchMock.sandbox();
+
+	fetch.get({
+		url: 'https://example.com/d2l/api/le/1.46/123/quizzes/'
+	}, {
+		Objects: [{
+			QuizId: 1,
+			Name: 'Test Quiz',
+			ActivityId: 'https://ids.brightspace.com/activities/quiz/Dev-1'
+		}]
+	});
+	fetch.get({
+		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
+	}, {
+		body: [{
+			Id: 3,
+			Title: 'Test Quiz',
+			ShortTitle: 'Test Quiz',
+			Type: 1,
+			TopicType: 3,
+			DueDate: null,
+			StartDate: null,
+			EndDate: null,
+			IsHidden: false,
+			IsLocked: false,
+			IsExempt: false,
+			OpenAsExternalResource: false
+		}]
+	});
+
+	const quiz = {
+		title: 'Test Quiz',
+		type: 'quiz'
+	};
+
+	const processor = new QuizProcessor({}, MockValence, fetch);
+	await processor.processQuiz(url, OrgUnit, quiz, ParentModule);
+
+	t.true(fetch.done());
+});

--- a/src/test/utility/topic-processor.test.js
+++ b/src/test/utility/topic-processor.test.js
@@ -1,0 +1,328 @@
+'use strict';
+
+const path = require('path');
+const test = require('ava');
+const FormData = require('form-data');
+const fetchMock = require('fetch-mock');
+
+const TopicProcessor = require('../../utility/topic-processor');
+
+const ContentPath = path.join(__dirname, '..', 'content');
+
+const MockValence = {
+	createAuthenticatedUrl(url) {
+		return url;
+	}
+};
+
+const OrgUnit = {
+	Id: 123,
+	Name: 'Org Unit',
+	Path: '/content/course123/'
+};
+
+const ParentModule = {
+	Id: 1,
+	Title: 'Test Module',
+	ShortTitle: 'Test Module',
+	Type: 0,
+	ModuleStartDate: null,
+	ModuleEndDate: null,
+	ModuleDueDate: '2020-01-01T00:00:00.000Z',
+	IsHidden: false,
+	IsLocked: false,
+	Description: {
+		Html: '<html></html>\n'
+	}
+};
+
+test('creates topic', async t => {
+	const url = new URL('https://example.com');
+	const fetch = fetchMock.sandbox();
+
+	fetch.get({
+		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
+	}, {
+		body: ''
+	});
+	fetch.post((url, options) => {
+		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/') {
+			return false;
+		}
+
+		const formdata = new FormData(options.body);
+		if (!formdata.getBuffer().toString('utf-8').includes('test-topic.html')) {
+			return false;
+		}
+
+		t.is(formdata.getBuffer().toString('utf-8'), `--${formdata.getBoundary()}\r\n`
+			+ 'Content-Disposition: form-data; name=""\r\n'
+			+ 'Content-Type: application/json\r\n\r\n'
+			+ '{"Title":"Test Topic","ShortTitle":"Test Topic","Type":1,"TopicType":1,"StartDate":null,"EndDate":null,"DueDate":null,"Url":"/content/course123/test-module/test-topic.html","IsHidden":false,"IsLocked":false,"IsExempt":true}\r\n'
+			+ `--${formdata.getBoundary()}\r\n`
+			+ 'Content-Disposition: form-data; name=""; filename="test-topic.html"\r\n'
+			+ 'Content-Type: text/html\r\n\r\n'
+			+ '<h1></h1>\n\r\n'
+			+ `--${formdata.getBoundary()}--\r\n`);
+
+		return true;
+	}, {
+		body: {
+			Id: 2,
+			Title: 'Test Topic',
+			Type: 1,
+			TopicType: 1,
+			StartDate: null,
+			EndDate: null,
+			DueDate: null,
+			IsHidden: false,
+			IsLocked: false,
+			IsExempt: true,
+			OpenAsExternalResource: false,
+			Description: {
+				Html: '<h1></h1>\n'
+			}
+		}
+	});
+
+	const topic = {
+		title: 'Test Topic',
+		type: 'topic',
+		fileName: 'test-module/test-topic.md'
+	};
+
+	const processor = new TopicProcessor({ contentPath: ContentPath }, MockValence, fetch);
+	await processor.processTopic({ instanceUrl: url, orgUnit: OrgUnit, topic, parentModule: ParentModule, isHidden: false });
+
+	t.true(fetch.done());
+});
+
+test('creates hidden topic', async t => {
+	const url = new URL('https://example.com');
+	const fetch = fetchMock.sandbox();
+
+	fetch.get({
+		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
+	}, {
+		body: ''
+	});
+
+	fetch.post((url, options) => {
+		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/') {
+			return false;
+		}
+
+		const formdata = new FormData(options.body);
+		if (!formdata.getBuffer().toString('utf-8').includes('resource.txt')) {
+			return false;
+		}
+
+		t.is(formdata.getBuffer().toString('utf-8'), `--${formdata.getBoundary()}\r\n`
+			+ 'Content-Disposition: form-data; name=""\r\n'
+			+ 'Content-Type: application/json\r\n\r\n'
+			+ '{"Title":"test-module/resource.txt","ShortTitle":"test-module/resource.txt","Type":1,"TopicType":1,"StartDate":null,"EndDate":null,"DueDate":null,"Url":"/content/course123/test-module/resource.txt","IsHidden":true,"IsLocked":false,"IsExempt":true}\r\n'
+			+ `--${formdata.getBoundary()}\r\n`
+			+ 'Content-Disposition: form-data; name=""; filename="resource.txt"\r\n'
+			+ 'Content-Type: text/html\r\n\r\n'
+			+ 'ABC\n\r\n'
+			+ `--${formdata.getBoundary()}--\r\n`);
+
+		return true;
+	}, {
+		body: {
+			Id: 3,
+			Title: 'test-module/resource.txt',
+			Type: 1,
+			TopicType: 1,
+			StartDate: null,
+			EndDate: null,
+			DueDate: null,
+			IsHidden: true,
+			IsLocked: false,
+			IsExempt: false,
+			OpenAsExternalResource: false
+		}
+	});
+
+	const topic = {
+		title: 'test-module/resource.txt',
+		type: 'resource',
+		fileName: 'test-module/resource.txt'
+	};
+
+	const processor = new TopicProcessor({ contentPath: ContentPath }, MockValence, fetch);
+	await processor.processTopic({ instanceUrl: url, orgUnit: OrgUnit, topic, parentModule: ParentModule, isHidden: true });
+
+	t.true(fetch.done());
+});
+
+test('updates topic', async t => {
+	const url = new URL('https://example.com');
+	const fetch = fetchMock.sandbox();
+
+	fetch.get({
+		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
+	}, {
+		body: [{
+			Id: 2,
+			Title: 'Test Topic',
+			ShortTitle: 'Test Topic',
+			Type: 1,
+			TopicType: 1,
+			DueDate: null,
+			StartDate: null,
+			EndDate: null,
+			IsHidden: false,
+			IsLocked: false,
+			IsExempt: true,
+			OpenAsExternalResource: false
+		}]
+	});
+	fetch.put((url, options) => {
+		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/topics/2') {
+			return false;
+		}
+
+		t.deepEqual(JSON.parse(options.body), {
+			Id: 2,
+			Title: 'Test Topic',
+			ShortTitle: 'Test Topic',
+			Type: 1,
+			TopicType: 1,
+			StartDate: null,
+			EndDate: null,
+			DueDate: null,
+			IsHidden: false,
+			IsLocked: false,
+			IsExempt: true,
+			OpenAsExternalResource: false,
+			ResetCompletionTracking: true,
+			Url: '/content/course123/test-module/test-topic.html'
+		});
+
+		return true;
+	}, {
+		status: 200
+	});
+	fetch.put((url, options) => {
+		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/topics/2/file') {
+			return false;
+		}
+
+		const formdata = new FormData(options.body);
+		t.is(formdata.getBuffer().toString('utf-8'), `--${formdata.getBoundary()}\r\n`
+			+ 'Content-Disposition: form-data; name="file"; filename="test-topic.html"\r\n'
+			+ 'Content-Type: text/html\r\n\r\n'
+			+ '<h1></h1>\n\r\n'
+			+ `--${formdata.getBoundary()}--\r\n`);
+
+		return true;
+	}, {
+		status: 200
+	});
+
+	const topic = {
+		title: 'Test Topic',
+		type: 'topic',
+		fileName: 'test-module/test-topic.md'
+	};
+
+	const processor = new TopicProcessor({ contentPath: ContentPath }, MockValence, fetch);
+	await processor.processTopic({ instanceUrl: url, orgUnit: OrgUnit, topic, parentModule: ParentModule, isHidden: false });
+
+	t.true(fetch.done());
+});
+
+test('updates hidden topic', async t => {
+	const url = new URL('https://example.com');
+	const fetch = fetchMock.sandbox();
+
+	fetch.get({
+		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
+	}, {
+		body: [{
+			Id: 3,
+			Title: 'test-module/resource.txt',
+			ShortTitle: 'test-module/resource.txt',
+			Type: 1,
+			TopicType: 1,
+			DueDate: null,
+			StartDate: null,
+			EndDate: null,
+			IsHidden: true,
+			IsLocked: false,
+			IsExempt: true,
+			OpenAsExternalResource: false
+		}]
+	});
+	fetch.put((url, options) => {
+		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/topics/3') {
+			return false;
+		}
+
+		if (!options.body.includes('resource.txt')) {
+			return false;
+		}
+
+		t.deepEqual(JSON.parse(options.body), {
+			Id: 3,
+			Title: 'test-module/resource.txt',
+			ShortTitle: 'test-module/resource.txt',
+			Type: 1,
+			TopicType: 1,
+			StartDate: null,
+			EndDate: null,
+			DueDate: null,
+			IsHidden: true,
+			IsLocked: false,
+			IsExempt: true,
+			OpenAsExternalResource: false,
+			ResetCompletionTracking: true,
+			Url: '/content/course123/test-module/resource.txt'
+		});
+
+		return true;
+	}, {
+		body: {
+			Id: 3,
+			Title: 'test-module/resource.txt',
+			ShortTitle: 'test-module/resource.txt',
+			Type: 1,
+			TopicType: 1,
+			StartDate: null,
+			EndDate: null,
+			DueDate: null,
+			IsHidden: true,
+			IsLocked: false,
+			IsExempt: true,
+			OpenAsExternalResource: false
+		}
+	});
+	fetch.put((url, options) => {
+		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/topics/3/file') {
+			return false;
+		}
+
+		const formdata = new FormData(options.body);
+		t.is(formdata.getBuffer().toString('utf-8'), `--${formdata.getBoundary()}\r\n`
+			+ 'Content-Disposition: form-data; name="file"; filename="resource.txt"\r\n'
+			+ 'Content-Type: text/html\r\n\r\n'
+			+ 'ABC\n\r\n'
+			+ `--${formdata.getBoundary()}--\r\n`);
+
+		return true;
+	}, {
+		status: 200
+	});
+
+	const topic = {
+		title: 'test-module/resource.txt',
+		type: 'resource',
+		fileName: 'test-module/resource.txt'
+	};
+
+	const processor = new TopicProcessor({ contentPath: ContentPath }, MockValence, fetch);
+	await processor.processTopic({ instanceUrl: url, orgUnit: OrgUnit, topic, parentModule: ParentModule, isHidden: false });
+
+	t.true(fetch.done());
+});

--- a/src/upload-course-content.js
+++ b/src/upload-course-content.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const fs = require('fs');
-const FormData = require('form-data');
+
+const { LPVersion } = require('./constants');
 
 module.exports = class UploadCourseContent {
 	constructor(
@@ -11,7 +12,10 @@ module.exports = class UploadCourseContent {
 			isDryRun
 		},
 		valence,
-		fetch = require('node-fetch')
+		{
+			fetch = require('node-fetch'),
+			ModuleProcessor = require('./utility/module-processor')
+		}
 	) {
 		this._fetch = fetch;
 		this._valence = valence;
@@ -20,6 +24,8 @@ module.exports = class UploadCourseContent {
 		this._dryRun = isDryRun;
 
 		this._markdownRegex = /.md$/i;
+
+		this._moduleProcessor = new ModuleProcessor({ contentPath: contentDirectory, isDryRun }, valence);
 	}
 
 	/**
@@ -32,263 +38,18 @@ module.exports = class UploadCourseContent {
 		orgUnitId
 	) {
 		const whoAmI = await this._whoAmI(instanceUrl);
-		console.log(`Running in user context: ${whoAmI.UniqueName}`);
+		console.log(`Running in user context: '${whoAmI.UniqueName}'`);
 
 		const orgUnit = await this._getOrgUnit(instanceUrl, orgUnitId);
-		console.log(`Found course offering: ${orgUnit.Name} with id ${orgUnit.Identifier}`);
+		console.log(`Found course offering: '${orgUnit.Name}' with id: '${orgUnit.Identifier}'`);
 
 		const manifest = await this._getManifest();
-		console.log('Loaded manifest');
 
 		// Order matters on creates, so not using .map()
 		for (const module of manifest.modules) {
 			// eslint-disable-next-line no-await-in-loop
-			await this._processModule(instanceUrl, orgUnit, module);
+			await this._moduleProcessor.processModule(instanceUrl, orgUnit, module);
 		}
-	}
-
-	async _processModule(instanceUrl, orgUnit, module, parentModule) {
-		console.log(`Processing module: ${module.title}`);
-
-		const items = await this._getContent(instanceUrl, orgUnit, parentModule);
-		let self = Array.isArray(items) && items.find(m => m.Type === 0 && m.Title === module.title);
-
-		if (self) {
-			await this._updateModule(instanceUrl, orgUnit, module, self);
-		} else {
-			self = await this._createModule(instanceUrl, orgUnit, module, parentModule);
-		}
-
-		// Order matters on creates, so not using .map()
-		for (const child of module.children) {
-			if (child.type === 'topic') {
-				// eslint-disable-next-line no-await-in-loop
-				await this._processTopic(instanceUrl, orgUnit, child, self);
-			} else if (child.type === 'resource') {
-				// eslint-disable-next-line no-await-in-loop
-				await this._processResource(instanceUrl, orgUnit, child, self);
-			} else {
-				// eslint-disable-next-line no-await-in-loop
-				await this._processModule(instanceUrl, orgUnit, child, self);
-			}
-		}
-	}
-
-	async _processResource(instanceUrl, orgUnit, resource, parentModule) {
-		console.log(`Processing resource: ${resource.fileName}`);
-
-		const topic = {
-			...resource,
-			...{
-				title: resource.fileName
-			}
-		};
-
-		return this._processTopic(instanceUrl, orgUnit, topic, parentModule, true);
-	}
-
-	async _processTopic(instanceUrl, orgUnit, topic, parentModule, isHidden = false) {
-		console.log(`Processing topic: ${topic.title}`);
-
-		const topics = await this._getContent(instanceUrl, orgUnit, parentModule);
-		const self = Array.isArray(topics) && topics.find(t => t.Type === 1 && t.TopicType === 1 && t.Title === topic.title);
-
-		if (self) {
-			await this._updateTopic(instanceUrl, orgUnit, topic, self, isHidden);
-			return self;
-		}
-
-		return this._createTopic(instanceUrl, orgUnit, topic, parentModule, isHidden);
-	}
-
-	async _createModule(instanceUrl, orgUnit, module, parentModule) {
-		console.log(`Creating module: ${module.title}`);
-
-		const url = parentModule
-			? new URL(`/d2l/api/le/1.34/${orgUnit.Identifier}/content/modules/${parentModule.Id}/structure/`, instanceUrl)
-			: new URL(`/d2l/api/le/1.34/${orgUnit.Identifier}/content/root/`, instanceUrl);
-		const signedUrl = this._valence.createAuthenticatedUrl(url, 'POST');
-
-		const descriptionFileName = module.descriptionFileName.replace(this._markdownRegex, '.html');
-		const description = await fs.promises.readFile(`${this._contentDir}/${descriptionFileName}`);
-
-		if (this._dryRun) {
-			return UploadCourseContent.DRY_RUN_FAKE_MODULE;
-		}
-
-		const response = await this._fetch(
-			signedUrl,
-			{
-				method: 'POST',
-				body: JSON.stringify({
-					Title: module.title,
-					ShortTitle: module.title,
-					Type: 0,
-					ModuleStartDate: null,
-					ModuleEndDate: null,
-					ModuleDueDate: module.dueDate || null,
-					IsHidden: false,
-					IsLocked: false,
-					Description: {
-						Html: description.toString('utf-8')
-					}
-				})
-			});
-
-		return response.json();
-	}
-
-	async _createTopic(instanceUrl, orgUnit, topic, parentModule, isHidden = false) {
-		const fileName = topic.fileName.replace(this._markdownRegex, '.html');
-
-		console.log(`Creating topic: ${topic.title} with file: ${orgUnit.Path}${fileName}`);
-
-		const url = new URL(`/d2l/api/le/1.34/${orgUnit.Identifier}/content/modules/${parentModule.Id}/structure/`, instanceUrl);
-		const signedUrl = this._valence.createAuthenticatedUrl(url, 'POST');
-
-		const fileContent = await fs.promises.readFile(`${this._contentDir}/${fileName}`);
-
-		const formData = new FormData();
-		formData.append(
-			'',
-			JSON.stringify({
-				Title: topic.title,
-				ShortTitle: topic.title,
-				Type: 1,
-				TopicType: 1,
-				StartDate: null,
-				EndDate: null,
-				DueDate: topic.dueDate || null,
-				Url: `${orgUnit.Path}${fileName}`,
-				IsHidden: isHidden,
-				IsLocked: false,
-				IsExempt: !topic.isRequired
-			}),
-			{ contentType: 'application/json' }
-		);
-		formData.append(
-			'',
-			fileContent,
-			{ contentType: 'text/html', filename: `${fileName}` }
-		);
-
-		if (this._dryRun) {
-			return {};
-		}
-
-		const response = await this._fetch(
-			signedUrl,
-			{
-				method: 'POST',
-				headers: {
-					'Content-Type': `multipart/mixed; boundary=${formData.getBoundary()}`
-				},
-				body: formData
-			});
-
-		return response.json();
-	}
-
-	async _updateModule(instanceUrl, orgUnit, module, lmsModule, isHidden = false) {
-		console.log(`Updating module ${module.title}`);
-
-		const url = new URL(`/d2l/api/le/1.34/${orgUnit.Identifier}/content/modules/${lmsModule.Id}`, instanceUrl);
-		const signedUrl = this._valence.createAuthenticatedUrl(url, 'PUT');
-
-		const descriptionFileName = module.descriptionFileName.replace(this._markdownRegex, '.html');
-		const description = await fs.promises.readFile(`${this._contentDir}/${descriptionFileName}`);
-
-		const body = {
-			...lmsModule,
-			...{
-				Title: module.title,
-				ShortTitle: module.title,
-				ModuleDueDate: module.dueDate || null,
-				IsHidden: isHidden,
-				Description: {
-					Html: description.toString('utf-8')
-				}
-			}
-		};
-
-		if (this._dryRun) {
-			return body;
-		}
-
-		await this._fetch(
-			signedUrl,
-			{
-				method: 'PUT',
-				body: JSON.stringify(body)
-			});
-
-		return body;
-	}
-
-	async _updateTopic(instanceUrl, orgUnit, topic, lmsTopic) {
-		const url = new URL(`/d2l/api/le/1.34/${orgUnit.Identifier}/content/topics/${lmsTopic.Id}`, instanceUrl);
-		const signedUrl = this._valence.createAuthenticatedUrl(url, 'PUT');
-
-		const fileName = topic.fileName.replace(this._markdownRegex, '.html');
-
-		console.log(`Updating ${topic.title} and file ${fileName}`);
-
-		const body = {
-			...lmsTopic,
-			...{
-				Title: topic.title,
-				ShortTitle: topic.title,
-				Url: `${orgUnit.Path}${fileName}`,
-				DueDate: topic.dueDate || null,
-				ResetCompletionTracking: true,
-				IsExempt: !topic.isRequired
-			}
-		};
-
-		const fileUrl = new URL(`/d2l/api/le/1.34/${orgUnit.Identifier}/content/topics/${lmsTopic.Id}/file`, instanceUrl);
-		const signedFileUrl = this._valence.createAuthenticatedUrl(fileUrl, 'PUT');
-		const fileContent = await fs.promises.readFile(`${this._contentDir}/${fileName}`);
-
-		const formData = new FormData();
-		formData.append(
-			'file',
-			fileContent,
-			{ contentType: 'text/html', filename: `${fileName}` }
-		);
-
-		if (this._dryRun) {
-			return body;
-		}
-
-		await this._fetch(
-			signedUrl,
-			{
-				method: 'PUT',
-				body: JSON.stringify(body)
-			});
-
-		await this._fetch(
-			signedFileUrl,
-			{
-				method: 'PUT',
-				headers: {
-					'Content-Type': `multipart/mixed; boundary=${formData.getBoundary()}`
-				},
-				body: formData
-			});
-
-		return body;
-	}
-
-	async _getContent(instanceUrl, orgUnit, parentModule = null) {
-		const url = parentModule
-			? new URL(`/d2l/api/le/1.34/${orgUnit.Identifier}/content/modules/${parentModule.Id}/structure/`, instanceUrl)
-			: new URL(`/d2l/api/le/1.34/${orgUnit.Identifier}/content/root/`, instanceUrl);
-		const signedUrl = this._valence.createAuthenticatedUrl(url, 'GET');
-
-		const response = await this._fetch(signedUrl);
-
-		return response.json();
 	}
 
 	async _getManifest() {
@@ -298,7 +59,7 @@ module.exports = class UploadCourseContent {
 	}
 
 	async _getOrgUnit(instanceUrl, orgUnitId) {
-		const url = new URL(`/d2l/api/lp/1.23/courses/${orgUnitId}`, instanceUrl);
+		const url = new URL(`/d2l/api/lp/${LPVersion}/courses/${orgUnitId}`, instanceUrl);
 		const signedUrl = this._valence.createAuthenticatedUrl(url, 'GET');
 
 		const response = await this._fetch(signedUrl);
@@ -307,15 +68,11 @@ module.exports = class UploadCourseContent {
 	}
 
 	async _whoAmI(instanceUrl) {
-		const url = new URL('/d2l/api/lp/1.23/users/whoami', instanceUrl);
+		const url = new URL(`/d2l/api/lp/${LPVersion}/users/whoami`, instanceUrl);
 		const signedUrl = this._valence.createAuthenticatedUrl(url, 'GET');
 
 		const response = await this._fetch(signedUrl);
 
 		return response.json();
-	}
-
-	static get DRY_RUN_FAKE_MODULE() {
-		return { Id: 23487 };
 	}
 };

--- a/src/utility/content-factory.js
+++ b/src/utility/content-factory.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = class ContentFactory {
+	static createRichText(content, type) {
+		return {
+			Content: content,
+			Type: type
+		};
+	}
+
+	static createModule({ title, description, dueDate = null }) {
+		return {
+			Title: title,
+			ShortTitle: title,
+			Type: 0,
+			ModuleStartDate: null,
+			ModuleEndDate: null,
+			ModuleDueDate: dueDate,
+			IsHidden: false,
+			IsLocked: false,
+			Description: description
+		};
+	}
+
+	static createTopic({ title, topicType = 1, dueDate = null, url, isHidden = false, isExempt = false }) {
+		return {
+			Title: title,
+			ShortTitle: title,
+			Type: 1,
+			TopicType: topicType,
+			StartDate: null,
+			EndDate: null,
+			DueDate: dueDate,
+			Url: url,
+			IsHidden: isHidden,
+			IsLocked: false,
+			IsExempt: isExempt
+		};
+	}
+};

--- a/src/utility/module-processor.js
+++ b/src/utility/module-processor.js
@@ -1,0 +1,168 @@
+'use strict';
+
+const fs = require('fs');
+
+const ContentFactory = require('./content-factory');
+const { DryRunFakeModule, LEVersion } = require('../constants');
+
+module.exports = class ModuleProcessor {
+	constructor(
+		{ contentPath, isDryRun = false },
+		valence,
+		{
+			fetch = require('node-fetch'),
+			TopicProcessor = require('./topic-processor'),
+			QuizProcessor = require('./quiz-processor')
+		}
+	) {
+		this._contentPath = contentPath;
+		this._dryRun = isDryRun;
+
+		this._fetch = fetch;
+		this._valence = valence;
+		this._topicProcessor = new TopicProcessor({ contentPath, isDryRun }, valence);
+		this._quizProcessor = new QuizProcessor({ isDryRun }, valence);
+
+		this._markdownRegex = /.md$/i;
+	}
+
+	async processModule(instanceUrl, orgUnit, module, parentModule = null) {
+		const items = await this._getContent(instanceUrl, orgUnit, parentModule);
+		let self = Array.isArray(items) && items.find(m => m.Type === 0 && m.Title === module.title);
+
+		if (self) {
+			await this._updateModule({ instanceUrl, orgUnit, module, lmsModule: self });
+		} else {
+			self = await this._createModule(instanceUrl, orgUnit, module, parentModule);
+		}
+
+		// Order matters on creates, so not using .map()
+		/* eslint-disable no-await-in-loop */
+		for (const child of module.children) {
+			switch (child.type) {
+				case 'module':
+					await this._processModule(instanceUrl, orgUnit, child, self);
+					break;
+				case 'quiz':
+					await this._quizProcessor.processQuiz(instanceUrl, orgUnit, child, self);
+					break;
+				case 'resource':
+					await this._processResource(instanceUrl, orgUnit, child, self);
+					break;
+				case 'topic':
+					await this._topicProcessor.processTopic({ instanceUrl, orgUnit, topic: child, parentModule: self });
+					break;
+				default:
+					throw new Error(`Unknown content type: ${child.type}`);
+			}
+		}
+		/* eslint-enable no-await-in-loop */
+	}
+
+	async _createModule(instanceUrl, orgUnit, module, parentModule) {
+		console.log(`Creating module: '${module.title}'`);
+
+		const url = parentModule
+			? new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Identifier}/content/modules/${parentModule.Id}/structure/`, instanceUrl)
+			: new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Identifier}/content/root/`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'POST');
+
+		const descriptionFileName = module.descriptionFileName.replace(this._markdownRegex, '.html');
+		const descriptionHtml = await fs.promises.readFile(`${this._contentPath}/${descriptionFileName}`);
+
+		if (this._dryRun) {
+			return DryRunFakeModule;
+		}
+
+		const description = ContentFactory.createRichText(descriptionHtml.toString('utf-8'), 'Html');
+
+		const createModule = ContentFactory.createModule({
+			title: module.title,
+			description,
+			dueDate: module.dueDate
+		});
+
+		const response = await this._fetch(
+			signedUrl,
+			{
+				method: 'POST',
+				body: JSON.stringify(createModule)
+			});
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return response.json();
+	}
+
+	async _updateModule({ instanceUrl, orgUnit, module, lmsModule, isHidden = false }) {
+		console.log(`Updating module: '${module.title}'`);
+
+		const url = new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Identifier}/content/modules/${lmsModule.Id}`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'PUT');
+
+		const descriptionFileName = module.descriptionFileName.replace(this._markdownRegex, '.html');
+		const descriptionHtml = await fs.promises.readFile(`${this._contentPath}/${descriptionFileName}`);
+
+		const description = ContentFactory.createRichText(descriptionHtml.toString('utf-8'), 'Html');
+
+		const body = {
+			...lmsModule,
+			...{
+				Title: module.title,
+				ShortTitle: module.title,
+				ModuleDueDate: module.dueDate || null,
+				IsHidden: isHidden,
+				Description: description
+			}
+		};
+
+		if (this._dryRun) {
+			return body;
+		}
+
+		const response = await this._fetch(
+			signedUrl,
+			{
+				method: 'PUT',
+				body: JSON.stringify(body)
+			});
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return body;
+	}
+
+	async _processResource(instanceUrl, orgUnit, resource, parentModule) {
+		const topic = {
+			...resource,
+			...{
+				title: resource.fileName
+			}
+		};
+
+		return this._topicProcessor.processTopic({ instanceUrl, orgUnit, topic, parentModule, isHidden: true });
+	}
+
+	async _getContent(instanceUrl, orgUnit, parentModule = null) {
+		const url = parentModule
+			? new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Identifier}/content/modules/${parentModule.Id}/structure/`, instanceUrl)
+			: new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Identifier}/content/root/`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'GET');
+
+		if (this._dryRun && parentModule.Id === DryRunFakeModule.Id) {
+			return DryRunFakeModule;
+		}
+
+		const response = await this._fetch(signedUrl);
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return response.json();
+	}
+};

--- a/src/utility/quiz-processor.js
+++ b/src/utility/quiz-processor.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const { DryRunFakeModule, LEVersion } = require('../constants');
+const ContentFactory = require('./content-factory');
+
+module.exports = class QuizProcessor {
+	constructor(
+		{ isDryRun = false },
+		valence,
+		fetch = require('node-fetch')
+	) {
+		this._dryRun = isDryRun;
+
+		this._fetch = fetch;
+		this._valence = valence;
+	}
+
+	async processQuiz(instanceUrl, orgUnit, quiz, parentModule) {
+		const quizzes = await this._getQuizzes(instanceUrl, orgUnit);
+		const quizItem = quizzes.Objects && Array.isArray(quizzes.Objects) && quizzes.Objects.find(x => x.Name === quiz.title);
+
+		const content = await this._getContent(instanceUrl, orgUnit, parentModule);
+		const self = Array.isArray(content) && content.find(x => x.Type === 1 && x.TopicType === 3 && x.Title === quiz.title);
+
+		if (self) {
+			// Nothing to do, the quicklink exists
+			return self;
+		}
+
+		return this._createQuizTopic({ instanceUrl, orgUnit, quiz, parentModule, quizItem });
+	}
+
+	async _createQuizTopic({ instanceUrl, orgUnit, quiz, parentModule, quizItem }) {
+		console.log(`Creating quiz topic: '${quiz.title}'`);
+
+		const url = new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Id}/content/modules/${parentModule.Id}/structure/`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'POST');
+
+		const rcode = quizItem.ActivityId.split('/').slice(-1)[0];
+		const topic = ContentFactory.createTopic({
+			title: quiz.title,
+			topicType: 3,
+			url: `/d2l/common/dialogs/quickLink/quickLink.d2l?ou=${orgUnit.Id}&type=quiz&rcode=${rcode}`
+		});
+
+		if (this._dryRun) {
+			return;
+		}
+
+		const response = await this._fetch(
+			signedUrl,
+			{
+				method: 'POST',
+				body: JSON.stringify(topic)
+			}
+		);
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return response.json();
+	}
+
+	async _getContent(instanceUrl, orgUnit, parentModule) {
+		const url = new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Id}/content/modules/${parentModule.Id}/structure/`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'GET');
+
+		if (this._dryRun && parentModule.Id === DryRunFakeModule.Id) {
+			return DryRunFakeModule;
+		}
+
+		const response = await this._fetch(signedUrl);
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return response.json();
+	}
+
+	async _getQuizzes(instanceUrl, orgUnit) {
+		const url = new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Id}/quizzes/`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'GET');
+
+		const response = await this._fetch(signedUrl);
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return response.json();
+	}
+};

--- a/src/utility/quiz-processor.js
+++ b/src/utility/quiz-processor.js
@@ -16,9 +16,6 @@ module.exports = class QuizProcessor {
 	}
 
 	async processQuiz(instanceUrl, orgUnit, quiz, parentModule) {
-		const quizzes = await this._getQuizzes(instanceUrl, orgUnit);
-		const quizItem = quizzes.Objects && Array.isArray(quizzes.Objects) && quizzes.Objects.find(x => x.Name === quiz.title);
-
 		const content = await this._getContent(instanceUrl, orgUnit, parentModule);
 		const self = Array.isArray(content) && content.find(x => x.Type === 1 && x.TopicType === 3 && x.Title === quiz.title);
 
@@ -26,6 +23,9 @@ module.exports = class QuizProcessor {
 			// Nothing to do, the quicklink exists
 			return self;
 		}
+
+		const quizzes = await this._getQuizzes(instanceUrl, orgUnit);
+		const quizItem = quizzes.Objects && Array.isArray(quizzes.Objects) && quizzes.Objects.find(x => x.Name === quiz.title);
 
 		return this._createQuizTopic({ instanceUrl, orgUnit, quiz, parentModule, quizItem });
 	}
@@ -40,7 +40,8 @@ module.exports = class QuizProcessor {
 		const topic = ContentFactory.createTopic({
 			title: quiz.title,
 			topicType: 3,
-			url: `/d2l/common/dialogs/quickLink/quickLink.d2l?ou=${orgUnit.Id}&type=quiz&rcode=${rcode}`
+			url: `/d2l/common/dialogs/quickLink/quickLink.d2l?ou=${orgUnit.Id}&type=quiz&rcode=${rcode}`,
+			isExempt: !quiz.isRequired
 		});
 
 		if (this._dryRun) {

--- a/src/utility/topic-processor.js
+++ b/src/utility/topic-processor.js
@@ -1,0 +1,161 @@
+'use strict';
+
+const fs = require('fs');
+const FormData = require('form-data');
+
+const { DryRunFakeModule, LEVersion } = require('../constants');
+const ContentFactory = require('./content-factory');
+
+module.exports = class TopicProcessor {
+	constructor(
+		{ contentPath, isDryRun = false },
+		valence,
+		fetch = require('node-fetch')
+	) {
+		this._contentPath = contentPath;
+		this._dryRun = isDryRun;
+
+		this._fetch = fetch;
+		this._valence = valence;
+
+		this._markdownRegex = /.md$/i;
+	}
+
+	async processTopic({ instanceUrl, orgUnit, topic, parentModule, isHidden = false }) {
+		const topics = await this._getContent(instanceUrl, orgUnit, parentModule);
+		const self = Array.isArray(topics) && topics.find(x => x.Type === 1 && x.TopicType === 1 && x.Title === topic.title);
+
+		if (self) {
+			await this._updateTopic(instanceUrl, orgUnit, topic, self);
+			return self;
+		}
+
+		return this._createTopic({ instanceUrl, orgUnit, topic, parentModule, isHidden });
+	}
+
+	async _createTopic({ instanceUrl, orgUnit, topic, parentModule, isHidden }) {
+		const fileName = topic.fileName.replace(this._markdownRegex, '.html');
+
+		console.log(`Creating topic: '${topic.title}' with file: '${fileName}'`);
+
+		const url = new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Id}/content/modules/${parentModule.Id}/structure/`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'POST');
+
+		const fileContent = await fs.promises.readFile(`${this._contentPath}/${fileName}`);
+
+		const createTopic = ContentFactory.createTopic({
+			title: topic.title,
+			url: `${orgUnit.Path}${fileName}`,
+			dueDate: topic.dueDate,
+			isHidden,
+			isExempt: !topic.isRequired
+		});
+
+		const formData = new FormData();
+		formData.append(
+			'',
+			JSON.stringify(createTopic),
+			{ contentType: 'application/json' }
+		);
+		formData.append(
+			'',
+			fileContent,
+			{ contentType: 'text/html', filename: `${fileName}` }
+		);
+
+		const response = await this._fetch(
+			signedUrl,
+			{
+				method: 'POST',
+				headers: `multipart/mixed; ${formData.getBoundary()}`,
+				body: formData
+			});
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return response.json();
+	}
+
+	async _updateTopic(instanceUrl, orgUnit, topic, lmsTopic) {
+		const fileName = topic.fileName.replace(this._markdownRegex, '.html');
+
+		console.log(`Updating topic: '${topic.title}' with file: '${fileName}'`);
+
+		const url = new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Id}/content/topics/${lmsTopic.Id}`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'PUT');
+
+		const body = {
+			...lmsTopic,
+			...{
+				Title: topic.title,
+				ShortTitle: topic.title,
+				Url: `${orgUnit.Path}${fileName}`,
+				DueDate: topic.dueDate || null,
+				ResetCompletionTracking: true,
+				IsExempt: !topic.isRequired
+			}
+		};
+
+		if (!this._dryRun) {
+			const response = await this._fetch(
+				signedUrl,
+				{
+					method: 'PUT',
+					body: JSON.stringify(body)
+				});
+
+			if (!response.ok) {
+				throw new Error(response.statusText);
+			}
+		}
+
+		const fileUrl = new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Id}/content/topics/${lmsTopic.Id}/file`, instanceUrl);
+		const signedFileUrl = this._valence.createAuthenticatedUrl(fileUrl, 'PUT');
+
+		const fileContent = await fs.promises.readFile(`${this._contentPath}/${fileName}`);
+
+		const formData = new FormData();
+		formData.append(
+			'file',
+			fileContent,
+			{ contentType: 'text/html', filename: `${fileName}` }
+		);
+
+		if (!this._dryRun) {
+			const fileResponse = await this._fetch(
+				signedFileUrl,
+				{
+					method: 'PUT',
+					headers: {
+						'Content-Type': 'multipart/mixed'
+					},
+					body: formData
+				});
+
+			if (!fileResponse.ok) {
+				throw new Error(fileResponse.statusText);
+			}
+		}
+
+		return body;
+	}
+
+	async _getContent(instanceUrl, orgUnit, parentModule) {
+		const url = new URL(`/d2l/api/le/${LEVersion}/${orgUnit.Id}/content/modules/${parentModule.Id}/structure/`, instanceUrl);
+		const signedUrl = this._valence.createAuthenticatedUrl(url, 'GET');
+
+		if (this._dryRun && parentModule.Id === DryRunFakeModule.Id) {
+			return DryRunFakeModule;
+		}
+
+		const response = await this._fetch(signedUrl);
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return response.json();
+	}
+};


### PR DESCRIPTION
Adds support for quizzes which are expected to exist in the orgunit
with a matching name, since QuizIds are not stable across orgUnits.

- [x] `npm run build` and commit

Fixes: #18