### PR TITLE
Fix validator getInstanceDomain to return URL object

### DIFF
--- a/src/test/validator.test.js
+++ b/src/test/validator.test.js
@@ -104,7 +104,7 @@ test('instanceDomain must be a URL', t => {
 test('instanceDomain returns the value', t => {
 	const core = new MockCore({instanceDomain: 'example.com'});
 	const validator = new Validator(core);
-	t.is('https://example.com', validator.getInstanceDomain());
+	t.deepEqual(new URL('https://example.com'), validator.getInstanceDomain());
 });
 
 test('courseOrgUnitId is required', t => {

--- a/src/validator.js
+++ b/src/validator.js
@@ -73,7 +73,7 @@ module.exports = class ActionValidator {
 			throw new TypeError('instanceDomain must be a domain. e.g. lms.example.com');
 		}
 
-		return instanceDomain;
+		return new URL(instanceDomain);
 	}
 
 	getCourseOrgUnitId() {


### PR DESCRIPTION
`uploadCourseContent` expects a `URL` type for the instanceUrl.