### PR TITLE
Rollback API versions by 2 releases

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6040,8 +6040,8 @@ module.exports = {
 	DryRunFakeModule: {
 		Id: 0
 	},
-	LEVersion: '1.46',
-	LPVersion: '1.28'
+	LEVersion: '1.44',
+	LPVersion: '1.26'
 };
 
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,6 +4,6 @@ module.exports = {
 	DryRunFakeModule: {
 		Id: 0
 	},
-	LEVersion: '1.46',
-	LPVersion: '1.28'
+	LEVersion: '1.44',
+	LPVersion: '1.26'
 };

--- a/src/test/upload-course-content.test.js
+++ b/src/test/upload-course-content.test.js
@@ -26,14 +26,14 @@ test('uploadCourseContent processes module', async t => {
 
 	const fetch = fetchMock.sandbox();
 	fetch.get({
-		url: 'https://example.com/d2l/api/lp/1.28/users/whoami'
+		url: 'https://example.com/d2l/api/lp/1.26/users/whoami'
 	}, {
 		body: {
 			UniqueName: 'Test User'
 		}
 	});
 	fetch.get({
-		url: 'https://example.com/d2l/api/lp/1.28/courses/123'
+		url: 'https://example.com/d2l/api/lp/1.26/courses/123'
 	}, {
 		body: {
 			Identifier: '123',

--- a/src/test/utility/module-processor.test.js
+++ b/src/test/utility/module-processor.test.js
@@ -48,12 +48,12 @@ test('creates module', async t => {
 
 	const fetch = fetchMock.sandbox();
 	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.46/123/content/root/'
+		url: 'https://example.com/d2l/api/le/1.44/123/content/root/'
 	}, {
 		body: ''
 	});
 	fetch.post((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/root/') {
+		if (url !== 'https://example.com/d2l/api/le/1.44/123/content/root/') {
 			return false;
 		}
 
@@ -163,7 +163,7 @@ test('updates module', async t => {
 
 	const fetch = fetchMock.sandbox();
 	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.46/123/content/root/'
+		url: 'https://example.com/d2l/api/le/1.44/123/content/root/'
 	}, {
 		body: [{
 			Id: 1,
@@ -181,7 +181,7 @@ test('updates module', async t => {
 		}]
 	});
 	fetch.put((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/modules/1') {
+		if (url !== 'https://example.com/d2l/api/le/1.44/123/content/modules/1') {
 			return false;
 		}
 
@@ -281,7 +281,7 @@ test('creates submodule', async t => {
 
 	const fetch = fetchMock.sandbox();
 	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
+		url: 'https://example.com/d2l/api/le/1.44/123/content/modules/1/structure/'
 	}, {
 		body: [{
 			Id: 1,
@@ -299,7 +299,7 @@ test('creates submodule', async t => {
 		}]
 	});
 	fetch.post((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/') {
+		if (url !== 'https://example.com/d2l/api/le/1.44/123/content/modules/1/structure/') {
 			return false;
 		}
 
@@ -422,7 +422,7 @@ test('updates submodule', async t => {
 
 	const fetch = fetchMock.sandbox();
 	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
+		url: 'https://example.com/d2l/api/le/1.44/123/content/modules/1/structure/'
 	}, {
 		body: [{
 			Id: 1,
@@ -453,7 +453,7 @@ test('updates submodule', async t => {
 		}]
 	});
 	fetch.put((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/modules/2') {
+		if (url !== 'https://example.com/d2l/api/le/1.44/123/content/modules/2') {
 			return false;
 		}
 

--- a/src/test/utility/quiz-processor.test.js
+++ b/src/test/utility/quiz-processor.test.js
@@ -37,7 +37,7 @@ test('creates quiz topic', async t => {
 	const fetch = fetchMock.sandbox();
 
 	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.46/123/quizzes/'
+		url: 'https://example.com/d2l/api/le/1.44/123/quizzes/'
 	}, {
 		Objects: [{
 			QuizId: 1,
@@ -46,12 +46,12 @@ test('creates quiz topic', async t => {
 		}]
 	});
 	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
+		url: 'https://example.com/d2l/api/le/1.44/123/content/modules/1/structure/'
 	}, {
 		body: []
 	});
 	fetch.post((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/') {
+		if (url !== 'https://example.com/d2l/api/le/1.44/123/content/modules/1/structure/') {
 			return false;
 		}
 
@@ -104,7 +104,7 @@ test('noop on existing quiz topic', async t => {
 	const fetch = fetchMock.sandbox();
 
 	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
+		url: 'https://example.com/d2l/api/le/1.44/123/content/modules/1/structure/'
 	}, {
 		body: [{
 			Id: 3,

--- a/src/test/utility/topic-processor.test.js
+++ b/src/test/utility/topic-processor.test.js
@@ -41,12 +41,12 @@ test('creates topic', async t => {
 	const fetch = fetchMock.sandbox();
 
 	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
+		url: 'https://example.com/d2l/api/le/1.44/123/content/modules/1/structure/'
 	}, {
 		body: ''
 	});
 	fetch.post((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/') {
+		if (url !== 'https://example.com/d2l/api/le/1.44/123/content/modules/1/structure/') {
 			return false;
 		}
 
@@ -102,13 +102,13 @@ test('creates hidden topic', async t => {
 	const fetch = fetchMock.sandbox();
 
 	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
+		url: 'https://example.com/d2l/api/le/1.44/123/content/modules/1/structure/'
 	}, {
 		body: ''
 	});
 
 	fetch.post((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/') {
+		if (url !== 'https://example.com/d2l/api/le/1.44/123/content/modules/1/structure/') {
 			return false;
 		}
 
@@ -161,7 +161,7 @@ test('updates topic', async t => {
 	const fetch = fetchMock.sandbox();
 
 	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
+		url: 'https://example.com/d2l/api/le/1.44/123/content/modules/1/structure/'
 	}, {
 		body: [{
 			Id: 2,
@@ -179,7 +179,7 @@ test('updates topic', async t => {
 		}]
 	});
 	fetch.put((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/topics/2') {
+		if (url !== 'https://example.com/d2l/api/le/1.44/123/content/topics/2') {
 			return false;
 		}
 
@@ -205,7 +205,7 @@ test('updates topic', async t => {
 		status: 200
 	});
 	fetch.put((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/topics/2/file') {
+		if (url !== 'https://example.com/d2l/api/le/1.44/123/content/topics/2/file') {
 			return false;
 		}
 
@@ -238,7 +238,7 @@ test('updates hidden topic', async t => {
 	const fetch = fetchMock.sandbox();
 
 	fetch.get({
-		url: 'https://example.com/d2l/api/le/1.46/123/content/modules/1/structure/'
+		url: 'https://example.com/d2l/api/le/1.44/123/content/modules/1/structure/'
 	}, {
 		body: [{
 			Id: 3,
@@ -256,7 +256,7 @@ test('updates hidden topic', async t => {
 		}]
 	});
 	fetch.put((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/topics/3') {
+		if (url !== 'https://example.com/d2l/api/le/1.44/123/content/topics/3') {
 			return false;
 		}
 
@@ -299,7 +299,7 @@ test('updates hidden topic', async t => {
 		}
 	});
 	fetch.put((url, options) => {
-		if (url !== 'https://example.com/d2l/api/le/1.46/123/content/topics/3/file') {
+		if (url !== 'https://example.com/d2l/api/le/1.44/123/content/topics/3/file') {
 			return false;
 		}
 


### PR DESCRIPTION
LP 1.28 and LE 1.46 are too recent for our test environment, rolled back to 1.26 and 1.44 respectively.